### PR TITLE
Add notes about localBuild and plugins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,37 @@ Read the [IntelliJ Platform Gradle Plugin Integration Tests](INTEGRATION_TESTS.m
 
 ## Link With Your Project
 It is possible to link your plugin project with the IntelliJ Platform Gradle Plugin project, so it'll be loaded and built as a module.
-To integrate it with another consumer-like project, add the following line in the Gradle settings file and refresh your Gradle configuration:
+
+To integrate it with another consumer-like project, you can add it as a local build:
+
+1. Add the following line in the Gradle settings file, `settings.gradle.kts`, pointing to the local repository:
 
 ```kotlin
 includeBuild("/path/to/gradle-intellij-plugin")
+```
+
+2. To ensure you're not pulling in the changes from the remote repository, comment the lines from `gradle/libs.versions.toml`
+
+```toml
+[versions]
+...
+# intelliJPlatform = "2.0.0-SNAPSHOT"
+...
+[plugins]
+...
+# intelliJPlatform = { id = "org.jetbrains.intellij.platform", version.ref = "intelliJPlatform" }
+```
+
+3. In `build.gradle.kts`, replace the plugin dependency with the local one:
+
+```kotlin
+// alias(libs.plugins.gradleIntelliJPlugin) // Gradle IntelliJ Plugin
+id("org.jetbrains.intellij")
+```
+4. Clean and build the project:
+
+```shell
+./gradlew clean buildPlugin
 ```
 
 ## Pull Requests


### PR DESCRIPTION
# Pull Request Details

Adds more details about how to add the plugin to a local plugin project, not sure if Gradle has changed since the original notes were written, but I needed to do this.

## Description

The notes could be expanded to do something like this [from S.O](https://stackoverflow.com/questions/75010164/how-to-create-a-build-gradle-file-that-allows-me-to-debug-into-my-dependency):

```
if (System.getProperty('USE_LOCAL_INTELLI_PLATFORM_GRADLE') == true) {
  includeBuild("/path/to/gradle-intellij-plugin")
}
```

## Motivation and Context

Helping to fix and figure out issues!

## How Has This Been Tested

I've ran this locally and can see the plugin now in my local plugin!
<img width="323" alt="image" src="https://github.com/JetBrains/intellij-platform-gradle-plugin/assets/225131/1113d046-e0dd-479f-82be-58eeb0702ac4">


## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html).
- [x] I have updated the documentation accordingly.
- [ ] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGELOG.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
