### PR TITLE
BuildFeature: specify correct property name in KDoc

### DIFF
--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/BuildFeature.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/BuildFeature.kt
@@ -14,7 +14,7 @@ import org.jetbrains.intellij.platform.gradle.utils.Logger
  * To enable or disable a particular feature, add a Project property to the `gradle.properties` file with the following pattern:
  *
  * ```
- * org.jetbrains.intellij.buildFeature.<buildFeatureName>=<true|false>
+ * org.jetbrains.intellij.platform.buildFeature.<buildFeatureName>=<true|false>
  * ```
  *
  * Switch to [org.gradle.api.configuration.BuildFeatures] when supporting Gradle 8.5+.


### PR DESCRIPTION
[The documentation](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-gradle-properties.html) mentions the proper prefix, but I was looking at the source code and spent some time trying to understand why I cannot disable binary releases (as a workaround for #1599).