### PR TITLE
add lib/modules as directory containing plugin jars

### DIFF
--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/artifacts/transform/CollectorTransformer.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/artifacts/transform/CollectorTransformer.kt
@@ -43,9 +43,14 @@ abstract class CollectorTransformer : TransformAction<TransformParameters.None> 
             when (productInfo) {
                 null -> {
                     path.forEachDirectoryEntry { entry ->
-                        entry.resolve("lib")
-                            .listDirectoryEntries("*.jar")
-                            .forEach { outputs.file(it) }
+                        listOfNotNull(
+                            entry.resolve("lib"),
+                            entry.resolve("lib/modules")
+                        ).flatMap {
+                            it.listDirectoryEntries("*.jar")
+                        }.forEach {
+                            outputs.file(it)
+                        }
                     }
                 }
 
@@ -112,7 +117,7 @@ internal fun collectBundledPluginsJars(intellijPlatformPath: Path) =
         .resolve("plugins")
         .listDirectoryEntries()
         .asSequence()
-        .map { it.resolve("lib") }
+        .flatMap { it.resolve("lib") + it.resolve("lib/modules") }
         .mapNotNull { it.takeIf { it.exists() } }
         .flatMap { it.listDirectoryEntries("*.jar") }
         .toSet()

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/extensions/aware/IntelliJPlatformPluginDependencyAware.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/extensions/aware/IntelliJPlatformPluginDependencyAware.kt
@@ -17,6 +17,7 @@ import org.jetbrains.intellij.platform.gradle.models.toPublication
 import org.jetbrains.intellij.platform.gradle.utils.asLenient
 import java.nio.file.Path
 import kotlin.io.path.Path
+import kotlin.io.path.exists
 import kotlin.io.path.listDirectoryEntries
 import kotlin.math.absoluteValue
 
@@ -106,7 +107,12 @@ private fun IntelliJPlatformPluginDependencyAware.createIntelliJPlatformBundledP
     requireNotNull(bundledPlugin) { "Could not find bundled plugin with ID: '$id'" }
 
     val artifactPath = Path(bundledPlugin.path)
-    val jars = artifactPath.resolve("lib").listDirectoryEntries("*.jar")
+    val jars = listOfNotNull(
+        artifactPath.resolve("lib"),
+        artifactPath.resolve("lib/modules").takeIf { it.exists() }
+    ).flatMap {
+        it.listDirectoryEntries("*.jar")
+    }
     val hash = artifactPath.hashCode().absoluteValue % 1000
 
     return dependencies.create(


### PR DESCRIPTION
Platform module "com.intellij.modules.structuralsearch" is required for plugin "com.intellij.java". But "intellij.java.structuralSearch.jar" is located under "lib/modules". So "lib/modules" should be included into a classpath for test configuration.