### PR TITLE
Add `targetProductPart` property to allow installing plugin on the frontend part when running in Split Mode (#1563)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [next]
 
+### Added
+- `targetProductPart` property is added to allow installing plugin on the frontend part when running in Split Mode [#1563](../../issues/1563)
+
 ### Fixed
 
 - Fix for: `coroutinesJavaAgentPath` specifies file `.../build/tmp/initializeIntelliJPlugin/coroutines-javaagent.jar` which doesn't exist

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/argumentProviders/SandboxArgumentProvider.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/argumentProviders/SandboxArgumentProvider.kt
@@ -4,14 +4,10 @@ package org.jetbrains.intellij.platform.gradle.argumentProviders
 
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.*
 import org.gradle.api.tasks.PathSensitivity.RELATIVE
 import org.gradle.process.CommandLineArgumentProvider
-import org.jetbrains.intellij.platform.gradle.tasks.RunIdeTask
+import org.jetbrains.intellij.platform.gradle.tasks.aware.SplitModeAware
 import org.jetbrains.intellij.platform.gradle.utils.asPath
 import java.io.File
 import java.nio.file.Path
@@ -78,10 +74,10 @@ class SandboxArgumentProviderSplitModeAware(
     val splitMode: Property<Boolean>,
 
     @Input
-    val targetProductPart: Property<RunIdeTask.TargetProductPart>,
+    val targetProductPart: Property<SplitModeAware.SplitModeTarget>,
 ) : SandboxArgumentProvider(sandboxConfigDirectory, sandboxPluginsDirectory, sandboxSystemDirectory, sandboxLogDirectory) {
     override fun computePluginPathProperties(): List<String> {
-        if (splitMode.get() && targetProductPart.get() == RunIdeTask.TargetProductPart.FRONTEND) {
+        if (splitMode.get() && targetProductPart.get() == SplitModeAware.SplitModeTarget.FRONTEND) {
             return listOfNotNull(
                 //specifies an empty directory to ensure that the plugin won't be loaded by the backend process
                 sandboxPluginsDirectory.ifExists { "-Didea.plugins.path=$it/backend" },

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension.kt
@@ -30,10 +30,7 @@ import org.jetbrains.intellij.platform.gradle.models.productInfo
 import org.jetbrains.intellij.platform.gradle.models.toPublication
 import org.jetbrains.intellij.platform.gradle.models.validateSupportedVersion
 import org.jetbrains.intellij.platform.gradle.providers.ProductReleasesValueSource
-import org.jetbrains.intellij.platform.gradle.tasks.BuildSearchableOptionsTask
-import org.jetbrains.intellij.platform.gradle.tasks.PatchPluginXmlTask
-import org.jetbrains.intellij.platform.gradle.tasks.PublishPluginTask
-import org.jetbrains.intellij.platform.gradle.tasks.SignPluginTask
+import org.jetbrains.intellij.platform.gradle.tasks.*
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.*
 import org.jetbrains.intellij.platform.gradle.tasks.aware.PluginVerifierAware
 import org.jetbrains.intellij.platform.gradle.tasks.aware.SigningAware
@@ -127,11 +124,19 @@ abstract class IntelliJPlatformExtension @Inject constructor(
      * is running a frontend part (JetBrains Client) which connects to the backend.
      *
      * This property allows running the IDE with backend and frontend parts running in separate processes.
-     * The developed plugin is installed in the backend part.
+     * The developed plugin is installed in the backend part by default, this can be changed via [targetProductPart].
      *
      * Default value: `false`
      */
     abstract val splitMode: Property<Boolean>
+
+    /**
+     * Taken into account only if [splitMode] is set to `true` and specifies in which part of the IDE the plugin
+     * should be installed when `runIde` task is executed: the backend process, the frontend process, or both.
+     * 
+     * Default value: [RunIdeTask.TargetProductPart.BACKEND] 
+     */
+    abstract val targetProductPart: Property<RunIdeTask.TargetProductPart>
 
     val pluginConfiguration
         get() = extensions.getByName<PluginConfiguration>(Extensions.PLUGIN_CONFIGURATION)

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension.kt
@@ -34,6 +34,7 @@ import org.jetbrains.intellij.platform.gradle.tasks.*
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.*
 import org.jetbrains.intellij.platform.gradle.tasks.aware.PluginVerifierAware
 import org.jetbrains.intellij.platform.gradle.tasks.aware.SigningAware
+import org.jetbrains.intellij.platform.gradle.tasks.aware.SplitModeAware
 import org.jetbrains.intellij.platform.gradle.toIntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.utils.asLenient
 import org.jetbrains.intellij.platform.gradle.utils.asPath
@@ -124,7 +125,7 @@ abstract class IntelliJPlatformExtension @Inject constructor(
      * is running a frontend part (JetBrains Client) which connects to the backend.
      *
      * This property allows running the IDE with backend and frontend parts running in separate processes.
-     * The developed plugin is installed in the backend part by default, this can be changed via [targetProductPart].
+     * The developed plugin is installed in the backend part by default, this can be changed via [splitModeTarget].
      *
      * Default value: `false`
      */
@@ -134,9 +135,9 @@ abstract class IntelliJPlatformExtension @Inject constructor(
      * Taken into account only if [splitMode] is set to `true` and specifies in which part of the IDE the plugin
      * should be installed when `runIde` task is executed: the backend process, the frontend process, or both.
      * 
-     * Default value: [RunIdeTask.TargetProductPart.BACKEND] 
+     * Default value: [SplitModeAware.SplitModeTarget.BACKEND]
      */
-    abstract val targetProductPart: Property<RunIdeTask.TargetProductPart>
+    abstract val splitModeTarget: Property<SplitModeAware.SplitModeTarget>
 
     val pluginConfiguration
         get() = extensions.getByName<PluginConfiguration>(Extensions.PLUGIN_CONFIGURATION)

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/plugins/project/partials/IntelliJPlatformBasePlugin.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/plugins/project/partials/IntelliJPlatformBasePlugin.kt
@@ -320,6 +320,7 @@ abstract class IntelliJPlatformBasePlugin : Plugin<Project> {
             projectName.convention(project.name)
             sandboxContainer.convention(project.layout.buildDirectory.dir(Sandbox.CONTAINER))
             splitMode.convention(false)
+            targetProductPart.convention(RunIdeTask.TargetProductPart.BACKEND)
 
             configureExtension<IntelliJPlatformExtension.PluginConfiguration>(Extensions.PLUGIN_CONFIGURATION) {
                 version.convention(project.provider { project.version.toString() })

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/plugins/project/partials/IntelliJPlatformBasePlugin.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/plugins/project/partials/IntelliJPlatformBasePlugin.kt
@@ -320,7 +320,7 @@ abstract class IntelliJPlatformBasePlugin : Plugin<Project> {
             projectName.convention(project.name)
             sandboxContainer.convention(project.layout.buildDirectory.dir(Sandbox.CONTAINER))
             splitMode.convention(false)
-            targetProductPart.convention(RunIdeTask.TargetProductPart.BACKEND)
+            splitModeTarget.convention(SplitModeAware.SplitModeTarget.BACKEND)
 
             configureExtension<IntelliJPlatformExtension.PluginConfiguration>(Extensions.PLUGIN_CONFIGURATION) {
                 version.convention(project.provider { project.version.toString() })

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PrepareSandboxTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PrepareSandboxTask.kt
@@ -179,10 +179,10 @@ abstract class PrepareSandboxTask : Sync(), SandboxProducerAware, SplitModeAware
      * Creates a properties file which will be passed to the frontend process when the IDE is started in Split Mode.
      */
     private fun createPropertiesFileForFrontend() {
-        val pluginsPath = when (targetProductPart.get()) {
-            RunIdeTask.TargetProductPart.FRONTEND, RunIdeTask.TargetProductPart.BACKEND_AND_FRONTEND ->
+        val pluginsPath = when (splitModeTarget.get()) {
+            SplitModeAware.SplitModeTarget.FRONTEND, SplitModeAware.SplitModeTarget.BACKEND_AND_FRONTEND ->
                 sandboxPluginsDirectory.asPath
-            RunIdeTask.TargetProductPart.BACKEND ->
+            SplitModeAware.SplitModeTarget.BACKEND ->
                 //specifies an empty directory to ensure that the plugin won't be loaded
                 sandboxPluginsDirectory.asPath.resolve("frontend")
         }
@@ -236,7 +236,7 @@ abstract class PrepareSandboxTask : Sync(), SandboxProducerAware, SplitModeAware
 
                 inputs.property("intellijPlatform.instrumentCode", extension.instrumentCode)
                 inputs.property("intellijPlatform.splitMode", extension.splitMode)
-                inputs.property("intellijPlatform.targetProductPart", extension.targetProductPart)
+                inputs.property("intellijPlatform.targetProductPart", extension.splitModeTarget)
                 inputs.files(runtimeConfiguration)
             }
     }

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTask.kt
@@ -72,17 +72,6 @@ abstract class RunIdeTask : JavaExec(), RunnableIdeAware, CustomIntelliJPlatform
         super.exec()
     }
 
-    /**
-     * Describes a part of the product where the developed plugin can be installed when running in [splitMode].
-     */
-    enum class TargetProductPart {
-        BACKEND,
-        FRONTEND,
-        BACKEND_AND_FRONTEND;
-
-        override fun toString() = name.lowercase().replace('_', '-')
-    }
-    
     companion object : Registrable {
         override fun register(project: Project) =
             project.registerTask<RunIdeTask>(Tasks.RUN_IDE) {

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTask.kt
@@ -13,7 +13,6 @@ import org.jetbrains.intellij.platform.gradle.Constants.Plugin
 import org.jetbrains.intellij.platform.gradle.Constants.Tasks
 import org.jetbrains.intellij.platform.gradle.tasks.aware.CustomIntelliJPlatformVersionAware
 import org.jetbrains.intellij.platform.gradle.tasks.aware.RunnableIdeAware
-import org.jetbrains.intellij.platform.gradle.tasks.aware.frontendPropertiesFilePath
 import org.jetbrains.intellij.platform.gradle.utils.asPath
 import kotlin.io.path.pathString
 
@@ -60,7 +59,7 @@ abstract class RunIdeTask : JavaExec(), RunnableIdeAware, CustomIntelliJPlatform
 
         if (splitMode.get()) {
             environment("JETBRAINS_CLIENT_JDK", runtimeDirectory.asPath.pathString)
-            environment("JETBRAINS_CLIENT_PROPERTIES", frontendPropertiesFilePath.pathString)
+            environment("JETBRAINS_CLIENT_PROPERTIES", frontendPropertiesFile.asPath.pathString)
 
             if (args.orEmpty().isNotEmpty()) {
                 throw InvalidUserDataException("Passing arguments directly is not supported in Split Mode. Use `argumentProviders` instead.")

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTask.kt
@@ -13,6 +13,7 @@ import org.jetbrains.intellij.platform.gradle.Constants.Plugin
 import org.jetbrains.intellij.platform.gradle.Constants.Tasks
 import org.jetbrains.intellij.platform.gradle.tasks.aware.CustomIntelliJPlatformVersionAware
 import org.jetbrains.intellij.platform.gradle.tasks.aware.RunnableIdeAware
+import org.jetbrains.intellij.platform.gradle.tasks.aware.frontendPropertiesFilePath
 import org.jetbrains.intellij.platform.gradle.utils.asPath
 import kotlin.io.path.pathString
 
@@ -59,6 +60,7 @@ abstract class RunIdeTask : JavaExec(), RunnableIdeAware, CustomIntelliJPlatform
 
         if (splitMode.get()) {
             environment("JETBRAINS_CLIENT_JDK", runtimeDirectory.asPath.pathString)
+            environment("JETBRAINS_CLIENT_PROPERTIES", frontendPropertiesFilePath.pathString)
 
             if (args.orEmpty().isNotEmpty()) {
                 throw InvalidUserDataException("Passing arguments directly is not supported in Split Mode. Use `argumentProviders` instead.")
@@ -70,6 +72,17 @@ abstract class RunIdeTask : JavaExec(), RunnableIdeAware, CustomIntelliJPlatform
         super.exec()
     }
 
+    /**
+     * Describes a part of the product where the developed plugin can be installed when running in [splitMode].
+     */
+    enum class TargetProductPart {
+        BACKEND,
+        FRONTEND,
+        BACKEND_AND_FRONTEND;
+
+        override fun toString() = name.lowercase().replace('_', '-')
+    }
+    
     companion object : Registrable {
         override fun register(project: Project) =
             project.registerTask<RunIdeTask>(Tasks.RUN_IDE) {

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/TestIdeTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/TestIdeTask.kt
@@ -98,6 +98,8 @@ abstract class TestIdeTask : Test(), TestableAware, CustomIntelliJPlatformVersio
                     sourceTask.sandboxPluginsDirectory,
                     sourceTask.sandboxSystemDirectory,
                     sourceTask.sandboxLogDirectory,
+                    project.provider { false },
+                    project.provider { null },
                 )
             )
 

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/aware/SandboxAware.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/aware/SandboxAware.kt
@@ -7,6 +7,8 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Internal
 import org.jetbrains.intellij.platform.gradle.Constants
 import org.jetbrains.intellij.platform.gradle.extensions.IntelliJPlatformExtension
+import org.jetbrains.intellij.platform.gradle.utils.asPath
+import java.nio.file.Path
 
 /**
  * The interface provides quick access to the sandbox container and specific directories located within it.
@@ -64,3 +66,9 @@ interface SandboxAware : IntelliJPlatformVersionAware {
     @get:Internal
     val sandboxLogDirectory: DirectoryProperty
 }
+
+/**
+ * Path to a properties file which will be used to configure the frontend process if the IDE is started in Split Mode. 
+ */
+val SandboxAware.frontendPropertiesFilePath: Path
+    get() = sandboxContainerDirectory.asPath.resolve("frontend.properties")

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/aware/SandboxAware.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/aware/SandboxAware.kt
@@ -3,12 +3,12 @@
 package org.jetbrains.intellij.platform.gradle.tasks.aware
 
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Internal
 import org.jetbrains.intellij.platform.gradle.Constants
 import org.jetbrains.intellij.platform.gradle.extensions.IntelliJPlatformExtension
-import org.jetbrains.intellij.platform.gradle.utils.asPath
-import java.nio.file.Path
 
 /**
  * The interface provides quick access to the sandbox container and specific directories located within it.
@@ -65,10 +65,11 @@ interface SandboxAware : IntelliJPlatformVersionAware {
      */
     @get:Internal
     val sandboxLogDirectory: DirectoryProperty
-}
 
-/**
- * Path to a properties file which will be used to configure the frontend process if the IDE is started in Split Mode. 
- */
-val SandboxAware.frontendPropertiesFilePath: Path
-    get() = sandboxContainerDirectory.asPath.resolve("frontend.properties")
+    /**
+     * Path to a properties file which will be used to configure the frontend process if the IDE is started in Split Mode.
+     */
+    @get:Internal
+    val frontendPropertiesFile: Provider<RegularFile>
+        get() = sandboxContainerDirectory.file("frontend.properties")
+}

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/aware/SplitModeAware.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/aware/SplitModeAware.kt
@@ -7,7 +7,6 @@ import org.gradle.api.tasks.Internal
 import org.jetbrains.intellij.platform.gradle.Constants.Constraints
 import org.jetbrains.intellij.platform.gradle.models.ProductInfo
 import org.jetbrains.intellij.platform.gradle.models.validateSupportedVersion
-import org.jetbrains.intellij.platform.gradle.tasks.RunIdeTask
 import org.jetbrains.intellij.platform.gradle.utils.toVersion
 
 /**
@@ -32,10 +31,10 @@ interface SplitModeAware : IntelliJPlatformVersionAware {
     /**
      * Specifies in which part of the product the developed plugin should be installed.
      * 
-     * Default value: [RunIdeTask.TargetProductPart.BACKEND]
+     * Default value: [SplitModeTarget.BACKEND]
      */
     @get:Internal
-    val targetProductPart: Property<RunIdeTask.TargetProductPart>
+    val splitModeTarget: Property<SplitModeTarget>
 
     /**
      * Validates that the resolved IntelliJ Platform supports Split Mode.
@@ -49,5 +48,16 @@ interface SplitModeAware : IntelliJPlatformVersionAware {
         if (splitMode.get() && currentBuildNumber < Constraints.MINIMAL_SPLIT_MODE_BUILD_NUMBER) {
             throw IllegalArgumentException("Split Mode requires the IntelliJ Platform in version '${Constraints.MINIMAL_SPLIT_MODE_BUILD_NUMBER}' or later, but '$currentBuildNumber' was provided.")
         }
+    }
+
+    /**
+     * Describes a part of the product where the developed plugin can be installed when running in [splitMode].
+     */
+    enum class SplitModeTarget {
+        BACKEND,
+        FRONTEND,
+        BACKEND_AND_FRONTEND;
+
+        override fun toString() = name.lowercase().replace('_', '-')
     }
 }

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/aware/SplitModeAware.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/aware/SplitModeAware.kt
@@ -7,6 +7,7 @@ import org.gradle.api.tasks.Internal
 import org.jetbrains.intellij.platform.gradle.Constants.Constraints
 import org.jetbrains.intellij.platform.gradle.models.ProductInfo
 import org.jetbrains.intellij.platform.gradle.models.validateSupportedVersion
+import org.jetbrains.intellij.platform.gradle.tasks.RunIdeTask
 import org.jetbrains.intellij.platform.gradle.utils.toVersion
 
 /**
@@ -27,6 +28,14 @@ interface SplitModeAware : IntelliJPlatformVersionAware {
      */
     @get:Internal
     val splitMode: Property<Boolean>
+
+    /**
+     * Specifies in which part of the product the developed plugin should be installed.
+     * 
+     * Default value: [RunIdeTask.TargetProductPart.BACKEND]
+     */
+    @get:Internal
+    val targetProductPart: Property<RunIdeTask.TargetProductPart>
 
     /**
      * Validates that the resolved IntelliJ Platform supports Split Mode.

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/tasks.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/tasks.kt
@@ -20,7 +20,6 @@ import org.jetbrains.intellij.platform.gradle.Constants.Extensions
 import org.jetbrains.intellij.platform.gradle.Constants.Sandbox
 import org.jetbrains.intellij.platform.gradle.Constants.Tasks
 import org.jetbrains.intellij.platform.gradle.argumentProviders.IntelliJPlatformArgumentProvider
-import org.jetbrains.intellij.platform.gradle.argumentProviders.SandboxArgumentProvider
 import org.jetbrains.intellij.platform.gradle.argumentProviders.SandboxArgumentProviderSplitModeAware
 import org.jetbrains.intellij.platform.gradle.argumentProviders.SplitModeArgumentProvider
 import org.jetbrains.intellij.platform.gradle.artifacts.transform.ExtractorTransformer
@@ -409,7 +408,7 @@ internal fun <T : Task> Project.preconfigureTask(task: T) {
          */
         if (this is SplitModeAware) {
             splitMode.convention(extension.splitMode)
-            targetProductPart.convention(extension.targetProductPart)
+            splitModeTarget.convention(extension.splitModeTarget)
         }
 
         /**
@@ -442,7 +441,7 @@ internal fun <T : Task> Project.preconfigureTask(task: T) {
                     sandboxSystemDirectory,
                     sandboxLogDirectory,
                     splitMode,
-                    targetProductPart,
+                    splitModeTarget,
                 )
             )
 

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/tasks.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/tasks.kt
@@ -21,6 +21,7 @@ import org.jetbrains.intellij.platform.gradle.Constants.Sandbox
 import org.jetbrains.intellij.platform.gradle.Constants.Tasks
 import org.jetbrains.intellij.platform.gradle.argumentProviders.IntelliJPlatformArgumentProvider
 import org.jetbrains.intellij.platform.gradle.argumentProviders.SandboxArgumentProvider
+import org.jetbrains.intellij.platform.gradle.argumentProviders.SandboxArgumentProviderSplitModeAware
 import org.jetbrains.intellij.platform.gradle.argumentProviders.SplitModeArgumentProvider
 import org.jetbrains.intellij.platform.gradle.artifacts.transform.ExtractorTransformer
 import org.jetbrains.intellij.platform.gradle.extensions.IntelliJPlatformDependenciesExtension
@@ -408,6 +409,7 @@ internal fun <T : Task> Project.preconfigureTask(task: T) {
          */
         if (this is SplitModeAware) {
             splitMode.convention(extension.splitMode)
+            targetProductPart.convention(extension.targetProductPart)
         }
 
         /**
@@ -434,11 +436,13 @@ internal fun <T : Task> Project.preconfigureTask(task: T) {
                 )
             )
             jvmArgumentProviders.add(
-                SandboxArgumentProvider(
+                SandboxArgumentProviderSplitModeAware(
                     sandboxConfigDirectory,
                     sandboxPluginsDirectory,
                     sandboxSystemDirectory,
                     sandboxLogDirectory,
+                    splitMode,
+                    targetProductPart,
                 )
             )
 

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/tasks.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/tasks.kt
@@ -20,7 +20,7 @@ import org.jetbrains.intellij.platform.gradle.Constants.Extensions
 import org.jetbrains.intellij.platform.gradle.Constants.Sandbox
 import org.jetbrains.intellij.platform.gradle.Constants.Tasks
 import org.jetbrains.intellij.platform.gradle.argumentProviders.IntelliJPlatformArgumentProvider
-import org.jetbrains.intellij.platform.gradle.argumentProviders.SandboxArgumentProviderSplitModeAware
+import org.jetbrains.intellij.platform.gradle.argumentProviders.SandboxArgumentProvider
 import org.jetbrains.intellij.platform.gradle.argumentProviders.SplitModeArgumentProvider
 import org.jetbrains.intellij.platform.gradle.artifacts.transform.ExtractorTransformer
 import org.jetbrains.intellij.platform.gradle.extensions.IntelliJPlatformDependenciesExtension
@@ -435,7 +435,7 @@ internal fun <T : Task> Project.preconfigureTask(task: T) {
                 )
             )
             jvmArgumentProviders.add(
-                SandboxArgumentProviderSplitModeAware(
+                SandboxArgumentProvider(
                     sandboxConfigDirectory,
                     sandboxPluginsDirectory,
                     sandboxSystemDirectory,

--- a/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PrepareSandboxTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PrepareSandboxTaskTest.kt
@@ -5,6 +5,7 @@ package org.jetbrains.intellij.platform.gradle.tasks
 import org.jetbrains.intellij.platform.gradle.*
 import org.jetbrains.intellij.platform.gradle.Constants.Sandbox
 import org.jetbrains.intellij.platform.gradle.Constants.Tasks
+import org.jetbrains.intellij.platform.gradle.tasks.aware.SplitModeAware
 import java.nio.file.Path
 import kotlin.io.path.*
 import kotlin.test.Ignore
@@ -364,19 +365,19 @@ class PrepareSandboxTaskTest : IntelliJPluginTestBase() {
 
     @Test
     fun `prepare sandbox for splitMode with plugin installed on frontend`() {
-        buildSandboxForSplitMode(RunIdeTask.TargetProductPart.FRONTEND)
+        buildSandboxForSplitMode(SplitModeAware.SplitModeTarget.FRONTEND)
         checkFrontendProperties(sandbox.resolve("plugins"))
     }
     
     @Test
     fun `prepare sandbox for splitMode with plugin installed on backend`() {
-        buildSandboxForSplitMode(RunIdeTask.TargetProductPart.BACKEND)
+        buildSandboxForSplitMode(SplitModeAware.SplitModeTarget.BACKEND)
         checkFrontendProperties(sandbox.resolve("plugins").resolve("frontend"))
     }
     
     @Test
     fun `prepare sandbox for splitMode with plugin installed on backend and frontend`() {
-        buildSandboxForSplitMode(RunIdeTask.TargetProductPart.BACKEND_AND_FRONTEND)
+        buildSandboxForSplitMode(SplitModeAware.SplitModeTarget.BACKEND_AND_FRONTEND)
         checkFrontendProperties(sandbox.resolve("plugins"))
     }
 
@@ -392,7 +393,7 @@ class PrepareSandboxTaskTest : IntelliJPluginTestBase() {
         )
     }
 
-    private fun buildSandboxForSplitMode(targetProductPart: RunIdeTask.TargetProductPart) {
+    private fun buildSandboxForSplitMode(targetProductPart: SplitModeAware.SplitModeTarget) {
         writeJavaFile()
 
         pluginXml write //language=xml

--- a/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PrepareSandboxTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PrepareSandboxTaskTest.kt
@@ -368,13 +368,13 @@ class PrepareSandboxTaskTest : IntelliJPluginTestBase() {
         buildSandboxForSplitMode(SplitModeAware.SplitModeTarget.FRONTEND)
         checkFrontendProperties(sandbox.resolve("plugins"))
     }
-    
+
     @Test
     fun `prepare sandbox for splitMode with plugin installed on backend`() {
         buildSandboxForSplitMode(SplitModeAware.SplitModeTarget.BACKEND)
         checkFrontendProperties(sandbox.resolve("plugins").resolve("frontend"))
     }
-    
+
     @Test
     fun `prepare sandbox for splitMode with plugin installed on backend and frontend`() {
         buildSandboxForSplitMode(SplitModeAware.SplitModeTarget.BACKEND_AND_FRONTEND)
@@ -385,33 +385,35 @@ class PrepareSandboxTaskTest : IntelliJPluginTestBase() {
         assertFileContent(
             sandbox.resolve("frontend.properties"),
             """
-                idea.config.path=${sandbox.resolve("config").resolve("frontend").pathString}
-                idea.system.path=${sandbox.resolve("system").resolve("frontend").pathString}
-                idea.log.path=${sandbox.resolve("log").resolve("frontend").pathString}
-                idea.plugins.path=$pluginsPath
-                """.trimIndent()
+            idea.config.path=${sandbox.resolve("config").resolve("frontend")}
+            idea.system.path=${sandbox.resolve("system").resolve("frontend")}
+            idea.log.path=${sandbox.resolve("log").resolve("frontend")}
+            idea.plugins.path=$pluginsPath
+            """.trimIndent()
         )
     }
 
-    private fun buildSandboxForSplitMode(targetProductPart: SplitModeAware.SplitModeTarget) {
+    private fun buildSandboxForSplitMode(splitModeTarget: SplitModeAware.SplitModeTarget) {
         writeJavaFile()
 
         pluginXml write //language=xml
                 """
-                    <idea-plugin />
-                    """.trimIndent()
+                <idea-plugin />
+                """.trimIndent()
 
-        buildFile prepend """
-                    import org.jetbrains.intellij.platform.gradle.tasks.RunIdeTask
-            """.trimIndent()
+        buildFile prepend // language=kotlin
+                """
+                import org.jetbrains.intellij.platform.gradle.tasks.aware.SplitModeAware
+                """.trimIndent()
 
         buildFile write //language=kotlin
                 """
-                    intellijPlatform {
-                        splitMode = true
-                        targetProductPart = RunIdeTask.TargetProductPart.${targetProductPart.name}
-                    }
-                    """.trimIndent()
+                intellijPlatform {
+                    sandboxContainer = file("${buildDirectory.resolve(Sandbox.CONTAINER)}")
+                    splitMode = true
+                    splitModeTarget = SplitModeAware.SplitModeTarget.${splitModeTarget.name}
+                }
+                """.trimIndent()
 
         build(Tasks.PREPARE_SANDBOX)
     }


### PR DESCRIPTION
`targetProductPart` property is added to `IntelliJPlatformExtension` and `SplitModeAware`. It controls in which part of the IDE the developed plugin is installed. To do that, `PrepareSandboxTask` generates a properties file which configures the frontend process started from Split Mode. The path to the file is passed via `JETBRAINS_CLIENT_PROPERTIES` environment variable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html).
- [ ] I have updated the documentation accordingly.
- [x] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CHANGELOG.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
