### PR TITLE
Fix Gradle configuration cache warnings in JarSearchableOptionsTask & PrepareJarSearchableOptionsTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Fix Gradle configuration cache warnings in `JarSearchableOptionsTask` & `PrepareJarSearchableOptionsTask`
 - Added `PrepareSandboxTask.pluginName` for easier accessing of the plugin directory name
 - Allow for using non-installer IDEs for plugin verification [#1715](../../issues/1715)
 - Added `bundledModule()` dependency extension helpers

--- a/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/BuildSearchableOptionsTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/BuildSearchableOptionsTaskTest.kt
@@ -51,4 +51,59 @@ class BuildSearchableOptionsTaskTest : SearchableOptionsTestBase() {
             assertTaskOutcome(Tasks.JAR_SEARCHABLE_OPTIONS, TaskOutcome.SKIPPED)
         }
     }
+
+    @Test
+    fun `build searchable options produces XML if enabled via property and explicitly configured`() {
+        pluginXml write getPluginXmlWithSearchableConfigurable()
+
+        getTestSearchableConfigurableJava() write getSearchableConfigurableCode()
+
+        gradleProperties write //language=properties
+                """
+                org.jetbrains.intellij.platform.buildSearchableOptions = true
+                """.trimIndent()
+
+
+        buildFile write //language=kotlin
+                """
+                intellijPlatform {
+                    buildSearchableOptions = true
+                }
+                """.trimIndent()
+
+        build(Tasks.BUILD_SEARCHABLE_OPTIONS) {
+            assertContains("Searchable options index builder completed", output)
+        }
+
+        val xml = buildDirectory.resolve("tmp/${Tasks.BUILD_SEARCHABLE_OPTIONS}/projectName-1.0.0.jar/search/projectName-1.0.0.jar.searchableOptions.xml")
+        assertExists(xml)
+
+        xml.readText().let {
+            assertContains("<configurable id=\"test.searchable.configurable\" configurable_name=\"Test Searchable Configurable\">", it)
+            assertContains("hit=\"Label for Test Searchable Configurable\"", it)
+        }
+    }
+
+    @Test
+    fun `skip build searchable options if disabled via property and explicitly configured`() {
+
+        gradleProperties write //language=properties
+                """
+                org.jetbrains.intellij.platform.buildSearchableOptions = false
+                """.trimIndent()
+
+        buildFile write //language=kotlin
+                """
+                intellijPlatform {
+                    buildSearchableOptions = providers.gradleProperty("org.jetbrains.intellij.platform.buildSearchableOptions").map {
+                        it.toBoolean()
+                    }
+                }
+                """.trimIndent()
+
+        build(Tasks.BUILD_PLUGIN) {
+            assertTaskOutcome(Tasks.BUILD_SEARCHABLE_OPTIONS, TaskOutcome.SKIPPED)
+            assertTaskOutcome(Tasks.JAR_SEARCHABLE_OPTIONS, TaskOutcome.SKIPPED)
+        }
+    }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/JarSearchableOptionsTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/JarSearchableOptionsTaskTest.kt
@@ -29,4 +29,60 @@ class JarSearchableOptionsTaskTest : SearchableOptionsTestBase() {
             assertEquals(setOf("projectName-1.0.0-searchableOptions.jar", "projectName-1.0.0-base.jar", "projectName-1.0.0.jar"), collectPaths(it))
         }
     }
+
+    @Test
+    fun `jar searchable options produces archive if enabled via property and explicitly configured`() {
+        pluginXml write getPluginXmlWithSearchableConfigurable()
+
+        gradleProperties write //language=properties
+                """
+                org.jetbrains.intellij.platform.buildSearchableOptions = true
+                """.trimIndent()
+
+        buildFile write //language=kotlin
+                """
+                intellijPlatform {
+                    buildSearchableOptions = providers.gradleProperty("org.jetbrains.intellij.platform.buildSearchableOptions").map {
+                        it.toBoolean()
+                    }
+                }
+                """.trimIndent()
+
+        getTestSearchableConfigurableJava() write getSearchableConfigurableCode()
+
+        build(Tasks.JAR_SEARCHABLE_OPTIONS)
+
+        buildDirectory.resolve("libs").let {
+            assertExists(it)
+            assertEquals(setOf("projectName-1.0.0-searchableOptions.jar", "projectName-1.0.0-base.jar", "projectName-1.0.0.jar"), collectPaths(it))
+        }
+    }
+
+    @Test
+    fun `jar searchable options disabled via property and explicitly configured`() {
+        pluginXml write getPluginXmlWithSearchableConfigurable()
+
+        gradleProperties write //language=properties
+                """
+                org.jetbrains.intellij.platform.buildSearchableOptions = false
+                """.trimIndent()
+
+        buildFile write //language=kotlin
+                """
+                intellijPlatform {
+                    buildSearchableOptions = providers.gradleProperty("org.jetbrains.intellij.platform.buildSearchableOptions").map {
+                        it.toBoolean()
+                    }
+                }
+                """.trimIndent()
+
+        getTestSearchableConfigurableJava() write getSearchableConfigurableCode()
+
+        build(Tasks.JAR_SEARCHABLE_OPTIONS)
+
+        buildDirectory.resolve("libs").let {
+            assertExists(it)
+            assertEquals(setOf("projectName-1.0.0-base.jar", "projectName-1.0.0.jar"), collectPaths(it))
+        }
+    }
 }


### PR DESCRIPTION
# Pull Request Details

Fix Gradle configuration cache warnings in JarSearchableOptionsTask & PrepareJarSearchableOptionsTask caused by lazy value calculation, which uses a task reference. It has been fixed by moving out the value of Task.enabled into a property and explicitly defining it as a task input. Also added explicit dependencies between buildSearchableOptions -> prepareJarSearchableOptions -> jarSearchableOptions.

## Description

Self-explanatory above.

## Related Issue

No ticket. Can be reproduced by "./gradlew buildPlugin" with
```
intellijPlatform {
    buildSearchableOptions = providers.gradleProperty("org.jetbrains.intellij.platform.buildSearchableOptions").map {
        it.toBoolean()
    }
```
![image](https://github.com/user-attachments/assets/926f9229-6b57-4775-b665-8a62999de688)

## Motivation and Context


## How Has This Been Tested

Integration tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CONTRIBUTING.md) document.
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html).
- [ ] I have updated the documentation accordingly.
- [x ] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CHANGELOG.md).
- [ x] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
