### PR TITLE
Fixed #1799 by creating a separate intellijPlatformComposedJarApi (extends api & compileOnlyApi) configuration with JAVA_API usage attribute value. Also replaced java plugin by java-library plugin, because it is a more proper plugin for IntelliJ plugin projects (they are libraries).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@
 
 ### Fixed
 
-- Fixed issue #1778 by removing a hash of the absolute artifact path appended to the end of the version string. That hash made artifact version different on different PCs and also breaks Gradle dependency locking.
-- Add the missing `org.jetbrains.kotlin.platform.type=jvm` attribute to the `intellijPlatformRuntimeClasspath` configuration manually as it's not inherited from the `runtimeClasspath`.
+- Fixed by removing a hash of the absolute artifact path appended to the end of the version string. That hash made an artifact version different on different PCs and also broke Gradle dependency locking. [#1778](../../issues/1778)
+- Add the missing `org.jetbrains.kotlin.platform.type=jvm` attribute to the `intellijPlatformRuntimeClasspath` configuration manually as it is not inherited from the `runtimeClasspath`.
 - Fixed `Could not generate a decorated class for type PluginArtifactRepository.` when creating a custom plugin repository.
 - Fixed generation of duplicate files in ".intellijPlatform/localPlatformArtifacts" with different version numbers.
-- #1799: Gradle's api & compileOnlyApi configurations created by its java-library plugin do not work, and transitive implementation scope dependencies get exposed, when this plugin is used.
+- Gradle's api & compileOnlyApi configurations created by its java-library plugin don't work, and transitive implementation scope dependencies get exposed, when this plugin is used. [#1799](../../issues/1799)
 
 ## [2.1.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add the missing `org.jetbrains.kotlin.platform.type=jvm` attribute to the `intellijPlatformRuntimeClasspath` configuration manually as it's not inherited from the `runtimeClasspath`.
 - Fixed `Could not generate a decorated class for type PluginArtifactRepository.` when creating a custom plugin repository.
 - Fixed generation of duplicate files in ".intellijPlatform/localPlatformArtifacts" with different version numbers.
+- #1799: Gradle's api & compileOnlyApi configurations created by its java-library plugin do not work, and transitive implementation scope dependencies get exposed, when this plugin is used.
 
 ## [2.1.0]
 

--- a/api/IntelliJPlatformGradlePlugin.api
+++ b/api/IntelliJPlatformGradlePlugin.api
@@ -84,7 +84,6 @@ public final class org/jetbrains/intellij/platform/gradle/Constants$Configuratio
 
 public final class org/jetbrains/intellij/platform/gradle/Constants$Configurations$External {
 	public static final field API Ljava/lang/String;
-	public static final field API_ELEMENTS Ljava/lang/String;
 	public static final field COMPILE_CLASSPATH Ljava/lang/String;
 	public static final field COMPILE_ONLY Ljava/lang/String;
 	public static final field COMPILE_ONLY_API Ljava/lang/String;

--- a/api/IntelliJPlatformGradlePlugin.api
+++ b/api/IntelliJPlatformGradlePlugin.api
@@ -19,6 +19,7 @@ public final class org/jetbrains/intellij/platform/gradle/Constants$Configuratio
 	public static final field INTELLIJ_PLATFORM_BUNDLED_PLUGINS Ljava/lang/String;
 	public static final field INTELLIJ_PLATFORM_CLASSPATH Ljava/lang/String;
 	public static final field INTELLIJ_PLATFORM_COMPOSED_JAR Ljava/lang/String;
+	public static final field INTELLIJ_PLATFORM_COMPOSED_JAR_API Ljava/lang/String;
 	public static final field INTELLIJ_PLATFORM_DEPENDENCIES Ljava/lang/String;
 	public static final field INTELLIJ_PLATFORM_DEPENDENCY Ljava/lang/String;
 	public static final field INTELLIJ_PLATFORM_DEPENDENCY_ARCHIVE Ljava/lang/String;
@@ -82,8 +83,11 @@ public final class org/jetbrains/intellij/platform/gradle/Constants$Configuratio
 }
 
 public final class org/jetbrains/intellij/platform/gradle/Constants$Configurations$External {
+	public static final field API Ljava/lang/String;
+	public static final field API_ELEMENTS Ljava/lang/String;
 	public static final field COMPILE_CLASSPATH Ljava/lang/String;
 	public static final field COMPILE_ONLY Ljava/lang/String;
+	public static final field COMPILE_ONLY_API Ljava/lang/String;
 	public static final field IMPLEMENTATION Ljava/lang/String;
 	public static final field INSTANCE Lorg/jetbrains/intellij/platform/gradle/Constants$Configurations$External;
 	public static final field RUNTIME_CLASSPATH Ljava/lang/String;

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@ ossrhUsername=
 ossrhPassword=
 
 gradleVersion=8.10.2
-org.gradle.jvmargs = -Xmx4G
 
+org.gradle.jvmargs=-Xmx4G
 org.gradle.caching=true
 #org.gradle.parallel=true
 # Dokka is incompatible with the configuration cache https://github.com/Kotlin/dokka/issues/1217

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@ ossrhUsername=
 ossrhPassword=
 
 gradleVersion=8.10.2
+org.gradle.jvmargs = -Xmx4G
 
 org.gradle.caching=true
 #org.gradle.parallel=true

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/Constants.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/Constants.kt
@@ -128,13 +128,12 @@ object Constants {
          * - [The Java plugin configurations](https://docs.gradle.org/current/userguide/java_plugin.html#resolvable_configurations)
          */
         object External {
+            const val API = JvmConstants.API_CONFIGURATION_NAME
             const val COMPILE_CLASSPATH = JvmConstants.COMPILE_CLASSPATH_CONFIGURATION_NAME
             const val COMPILE_ONLY = JvmConstants.COMPILE_ONLY_CONFIGURATION_NAME
             const val COMPILE_ONLY_API = JvmConstants.COMPILE_ONLY_API_CONFIGURATION_NAME
-            const val API = JvmConstants.API_CONFIGURATION_NAME
             const val IMPLEMENTATION = JvmConstants.IMPLEMENTATION_CONFIGURATION_NAME
             const val RUNTIME_CLASSPATH = JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME
-            const val API_ELEMENTS = JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME
             const val RUNTIME_ELEMENTS = JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME
             const val RUNTIME_ONLY = JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME
             const val TEST_COMPILE_CLASSPATH = JvmConstants.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/Constants.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/Constants.kt
@@ -57,8 +57,13 @@ object Constants {
         const val INTELLIJ_PLATFORM = "intellijPlatform"
     }
 
+    /**
+     * See:
+     * - [Variant-aware sharing of artifacts between projects](https://docs.gradle.org/current/userguide/cross_project_publications.html#sec:variant-aware-sharing)
+     */
     object Configurations {
         const val INTELLIJ_PLATFORM_COMPOSED_JAR = "intellijPlatformComposedJar"
+        const val INTELLIJ_PLATFORM_COMPOSED_JAR_API = "intellijPlatformComposedJarApi"
         const val INTELLIJ_PLATFORM_DEPENDENCY_ARCHIVE = "intellijPlatformDependencyArchive"
         const val INTELLIJ_PLATFORM_DISTRIBUTION = "intellijPlatformDistribution"
         const val INTELLIJ_PLATFORM_LOCAL = "intellijPlatformLocal"
@@ -117,11 +122,19 @@ object Constants {
             const val MARKETPLACE_GROUP = "com.jetbrains.plugins"
         }
 
+        /**
+         * See:
+         * - [The Java Library plugin configurations](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph)
+         * - [The Java plugin configurations](https://docs.gradle.org/current/userguide/java_plugin.html#resolvable_configurations)
+         */
         object External {
             const val COMPILE_CLASSPATH = JvmConstants.COMPILE_CLASSPATH_CONFIGURATION_NAME
             const val COMPILE_ONLY = JvmConstants.COMPILE_ONLY_CONFIGURATION_NAME
+            const val COMPILE_ONLY_API = JvmConstants.COMPILE_ONLY_API_CONFIGURATION_NAME
+            const val API = JvmConstants.API_CONFIGURATION_NAME
             const val IMPLEMENTATION = JvmConstants.IMPLEMENTATION_CONFIGURATION_NAME
             const val RUNTIME_CLASSPATH = JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME
+            const val API_ELEMENTS = JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME
             const val RUNTIME_ELEMENTS = JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME
             const val RUNTIME_ONLY = JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME
             const val TEST_COMPILE_CLASSPATH = JvmConstants.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/attributes/ComposedJarRule.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/attributes/ComposedJarRule.kt
@@ -7,10 +7,15 @@ import org.gradle.api.attributes.CompatibilityCheckDetails
 import org.gradle.api.attributes.LibraryElements
 import org.jetbrains.intellij.platform.gradle.Constants.Configurations.Attributes
 
+/**
+ * See:
+ * - [Attribute Matching](https://docs.gradle.org/current/userguide/variant_attributes.html#sec:attribute_matching)
+ * - [Variant-aware sharing of artifacts between projects](https://docs.gradle.org/current/userguide/cross_project_publications.html#sec:variant-aware-sharing)
+ */
 abstract class ComposedJarRule : AttributeCompatibilityRule<LibraryElements> {
 
     override fun execute(details: CompatibilityCheckDetails<LibraryElements>) = details.run {
-        if (consumerValue?.name == Attributes.COMPOSED_JAR_NAME && producerValue?.name == "jar") {
+        if (consumerValue?.name == Attributes.COMPOSED_JAR_NAME && producerValue?.name == LibraryElements.JAR) {
             compatible()
         }
     }

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/attributes/DistributionRule.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/attributes/DistributionRule.kt
@@ -7,10 +7,15 @@ import org.gradle.api.attributes.CompatibilityCheckDetails
 import org.gradle.api.attributes.LibraryElements
 import org.jetbrains.intellij.platform.gradle.Constants.Configurations.Attributes
 
+/**
+ * See:
+ * - [Attribute Matching](https://docs.gradle.org/current/userguide/variant_attributes.html#sec:attribute_matching)
+ * - [Variant-aware sharing of artifacts between projects](https://docs.gradle.org/current/userguide/cross_project_publications.html#sec:variant-aware-sharing)
+ */
 abstract class DistributionRule : AttributeCompatibilityRule<LibraryElements> {
 
     override fun execute(details: CompatibilityCheckDetails<LibraryElements>) = details.run {
-        if (consumerValue?.name == Attributes.DISTRIBUTION_NAME && producerValue?.name == "jar") {
+        if (consumerValue?.name == Attributes.DISTRIBUTION_NAME && producerValue?.name == LibraryElements.JAR) {
             compatible()
         }
     }

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/plugins/project/IntelliJPlatformBasePlugin.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/plugins/project/IntelliJPlatformBasePlugin.kt
@@ -5,7 +5,7 @@ package org.jetbrains.intellij.platform.gradle.plugins.project
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaLibraryPlugin
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.get
 import org.gradle.plugins.ide.idea.IdeaPlugin
@@ -43,7 +43,10 @@ abstract class IntelliJPlatformBasePlugin : Plugin<Project> {
         checkGradleVersion()
 
         with(project.plugins) {
-            apply(JavaPlugin::class)
+            // https://docs.gradle.org/current/userguide/java_plugin.html
+            // https://docs.gradle.org/current/userguide/java_library_plugin.html
+            apply(JavaLibraryPlugin::class)
+            // https://docs.gradle.org/current/userguide/idea_plugin.html
             apply(IdeaPlugin::class)
         }
 

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/plugins/project/IntelliJPlatformModulePlugin.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/plugins/project/IntelliJPlatformModulePlugin.kt
@@ -5,11 +5,7 @@ package org.jetbrains.intellij.platform.gradle.plugins.project
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.attributes.AttributeContainer
-import org.gradle.api.attributes.Bundling
-import org.gradle.api.attributes.Category
-import org.gradle.api.attributes.LibraryElements
-import org.gradle.api.attributes.Usage
+import org.gradle.api.attributes.*
 import org.gradle.api.attributes.java.TargetJvmVersion
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.kotlin.dsl.*
@@ -45,7 +41,7 @@ abstract class IntelliJPlatformModulePlugin : Plugin<Project> {
         // https://docs.gradle.org/current/userguide/variant_attributes.html#sec:standard_attributes
         // https://docs.gradle.org/current/userguide/cross_project_publications.html#sec:variant-aware-sharing
         with(project.configurations) configurations@{
-            fun Configuration.applyVariantCommonAttributes(customAction: AttributeContainer.() -> Unit = {}) {
+            fun Configuration.applyVariantCommonAttributes(block: AttributeContainer.() -> Unit = {}) {
                 attributes {
                     attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling.EXTERNAL))
                     attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category.LIBRARY))
@@ -61,7 +57,7 @@ abstract class IntelliJPlatformModulePlugin : Plugin<Project> {
                     attributes.attribute(Attributes.jvmEnvironment, "standard-jvm")
                     attributes.attribute(Attributes.kotlinJPlatformType, "jvm")
 
-                    customAction()
+                    block()
                 }
             }
 
@@ -69,11 +65,14 @@ abstract class IntelliJPlatformModulePlugin : Plugin<Project> {
                 name = Configurations.INTELLIJ_PLATFORM_COMPOSED_JAR_API,
                 description = "IntelliJ Platform final composed Jar archive Api",
             ) {
-                // true & true is deprecated.
-                // https://docs.gradle.org/current/userguide/declaring_dependencies_adv.html#sec:resolvable-consumable-configs
-                // > For backwards compatibility, both flags have a default value of true, but as a plugin author,
-                // you should always determine the right values for those flags, or you might accidentally introduce
-                // resolution errors.
+                /**
+                 * Setting both flags to `true` is deprecated:
+                 *
+                 * > For backwards compatibility, both flags have a default value of true, but as a plugin author,
+                 * > you should always determine the right values for those flags, or you might accidentally introduce resolution errors.
+                 *
+                 * See: https://docs.gradle.org/current/userguide/declaring_dependencies_adv.html#sec:resolvable-consumable-configs
+                 */
                 isCanBeConsumed = true
                 isCanBeResolved = false
 
@@ -82,12 +81,15 @@ abstract class IntelliJPlatformModulePlugin : Plugin<Project> {
                     attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(Attributes.COMPOSED_JAR_NAME))
                 }
 
-                // A separate consumable _API configuration is necessary so that we can register a separate outgoing variant
-                // with `attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_API))` so that custom
-                // configurations api & compileOnlyApi created by `java-library` plugin can actually work.
-                // https://docs.gradle.org/current/userguide/java_library_plugin.html
-                // We cannot extend here from Configurations.External.COMPILE_ONLY_API.API_ELEMENTS because then
-                // we will inherit its -base.jar registered by the java plugin by default, which we do not want.
+                /**
+                 * A separate consumable [Configurations.INTELLIJ_PLATFORM_COMPOSED_JAR_API] configuration is necessary so that we can register
+                 * a separate outgoing variant with `attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_API))` so that custom
+                 * configurations `api` & `compileOnlyApi` created by the `java-library` plugin can actually work.
+                 * See: https://docs.gradle.org/current/userguide/java_library_plugin.html
+                 *
+                 * We can't extend here from [Configurations.External.COMPILE_ONLY_API.API_ELEMENTS] because then
+                 * we will inherit its `-base.jar` registered by the java plugin by default, which we don't want.
+                 */
                 extendsFrom(
                     this@configurations[Configurations.External.API],
                     this@configurations[Configurations.External.COMPILE_ONLY_API]
@@ -106,8 +108,10 @@ abstract class IntelliJPlatformModulePlugin : Plugin<Project> {
                     attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(Attributes.COMPOSED_JAR_NAME))
                 }
 
-                // We cannot extend here from Configurations.External.COMPILE_ONLY_API.RUNTIME_ELEMENTS because then
-                // we will inherit its -base.jar registered by the java plugin by default, which we do not want.
+                /**
+                 * We can't extend here from [Configurations.External.RUNTIME_ELEMENTS] because then
+                 * we will inherit its `-base.jar` registered by the java plugin by default, which we don't want.
+                 */
                 extendsFrom(
                     this@configurations[Configurations.External.IMPLEMENTATION],
                     this@configurations[Configurations.External.RUNTIME_ONLY],
@@ -117,11 +121,14 @@ abstract class IntelliJPlatformModulePlugin : Plugin<Project> {
                 name = Configurations.INTELLIJ_PLATFORM_DISTRIBUTION,
                 description = "IntelliJ Platform distribution Zip archive",
             ) {
-                // true & true is deprecated.
-                // https://docs.gradle.org/current/userguide/declaring_dependencies_adv.html#sec:resolvable-consumable-configs
-                // > For backwards compatibility, both flags have a default value of true, but as a plugin author,
-                // you should always determine the right values for those flags, or you might accidentally introduce
-                // resolution errors.
+                /**
+                 * Setting both flags to `true` is deprecated:
+                 *
+                 * > For backwards compatibility, both flags have a default value of true, but as a plugin author,
+                 * > you should always determine the right values for those flags, or you might accidentally introduce resolution errors.
+                 *
+                 * See: https://docs.gradle.org/current/userguide/declaring_dependencies_adv.html#sec:resolvable-consumable-configs
+                 */
                 isCanBeConsumed = true
                 isCanBeResolved = false
 

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/ComposedJarTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/ComposedJarTask.kt
@@ -25,11 +25,11 @@ import org.jetbrains.intellij.platform.gradle.utils.extensionProvider
  *
  * The final Jar is also combined with plugin modules marked using the [IntelliJPlatformDependenciesExtension.pluginModule] dependencies helper.
  *
- * To understand what is going on in this class read & watch this:
- * - [1](https://youtu.be/2gPJD0mAres?t=461)
- * - [2](https://www.youtube.com/watch?v=8z5KFCLZDd0)
- * - [3](https://docs.gradle.org/current/userguide/variant_attributes.html#sec:standard_attributes)
- * - [4](https://docs.gradle.org/current/userguide/cross_project_publications.html#sec:variant-aware-sharing)
+ * To understand what is going on in this class read and watch:
+ * - [Understanding Gradle #13 – Aggregating Custom Artifacts](https://youtu.be/2gPJD0mAres?t=461)
+ * - [Understanding Gradle #12 – Publishing Libraries](https://www.youtube.com/watch?v=8z5KFCLZDd0)
+ * - [Working with Variant Attributes](https://docs.gradle.org/current/userguide/variant_attributes.html#sec:standard_attributes)
+ * - [Variant-aware sharing of artifacts between projects](https://docs.gradle.org/current/userguide/cross_project_publications.html#sec:variant-aware-sharing)
  */
 @CacheableTask
 abstract class ComposedJarTask : Jar() {

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/ComposedJarTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/ComposedJarTask.kt
@@ -24,6 +24,12 @@ import org.jetbrains.intellij.platform.gradle.utils.extensionProvider
  * depending on if code instrumentation is enabled with [IntelliJPlatformExtension.instrumentCode].
  *
  * The final Jar is also combined with plugin modules marked using the [IntelliJPlatformDependenciesExtension.pluginModule] dependencies helper.
+ *
+ * To understand what is going on in this class read & watch this:
+ * - [1](https://youtu.be/2gPJD0mAres?t=461)
+ * - [2](https://www.youtube.com/watch?v=8z5KFCLZDd0)
+ * - [3](https://docs.gradle.org/current/userguide/variant_attributes.html#sec:standard_attributes)
+ * - [4](https://docs.gradle.org/current/userguide/cross_project_publications.html#sec:variant-aware-sharing)
  */
 @CacheableTask
 abstract class ComposedJarTask : Jar() {
@@ -41,6 +47,7 @@ abstract class ComposedJarTask : Jar() {
                 val instrumentedJarTaskProvider = project.tasks.named<Jar>(Tasks.INSTRUMENTED_JAR)
                 val intellijPlatformPluginModuleConfiguration = project.configurations[Configurations.INTELLIJ_PLATFORM_PLUGIN_MODULE]
                 val intellijPlatformComposedJarConfiguration = project.configurations[Configurations.INTELLIJ_PLATFORM_COMPOSED_JAR]
+                val intellijPlatformComposedJarApiConfiguration = project.configurations[Configurations.INTELLIJ_PLATFORM_COMPOSED_JAR_API]
 
                 val sourceTaskProvider = project.extensionProvider.flatMap {
                     it.instrumentCode.flatMap { value ->
@@ -64,7 +71,8 @@ abstract class ComposedJarTask : Jar() {
                 duplicatesStrategy = DuplicatesStrategy.EXCLUDE
                 JarCompanion.applyPluginManifest(this)
 
-                project.artifacts.add(intellijPlatformComposedJarConfiguration.name, this)
+                intellijPlatformComposedJarConfiguration.outgoing.artifact(this)
+                intellijPlatformComposedJarApiConfiguration.outgoing.artifact(this)
 
                 softwareComponentFactory.adhoc(Components.INTELLIJ_PLATFORM).apply {
                     project.components.add(this)


### PR DESCRIPTION
# Pull Request Details

Fixed #1799 by creating a separate intellijPlatformComposedJarApi (extends api & compileOnlyApi) configuration with JAVA_API usage attribute value. Also replaced java plugin by java-library plugin, because it is a more proper plugin for IntelliJ plugin projects (they are libraries).

This PR includes #1792, because it is not merged yet, which I need to fix tests, since master is broken right now 
The actual fix for this issue can be seen in https://github.com/JetBrains/intellij-platform-gradle-plugin/pull/1800/commits/d1c8ef8719b60b7119cad4bbf122c58330d5d378

## Description

:point_up: + see #1799

These changes create a new outgoing variant:
```
--------------------------------------------------
Variant intellijPlatformComposedJar
--------------------------------------------------
IntelliJ Platform final composed Jar archive

Capabilities
    - 123:subpr:unspecified (default capability)
Attributes
    - org.gradle.category                = library
    - org.gradle.dependency.bundling     = external
    - org.gradle.jvm.environment         = standard-jvm
    - org.gradle.jvm.version             = 22
    - org.gradle.libraryelements         = composed-jar
    - org.gradle.usage                   = java-runtime
    - org.jetbrains.kotlin.platform.type = jvm
Artifacts
    - build/libs/subpr.jar (artifactType = jar)

--------------------------------------------------
Variant intellijPlatformComposedJarApi
--------------------------------------------------
IntelliJ Platform final composed Jar archive Api

Capabilities
    - 123:subpr:unspecified (default capability)
Attributes
    - org.gradle.category                = library
    - org.gradle.dependency.bundling     = external
    - org.gradle.jvm.environment         = standard-jvm
    - org.gradle.jvm.version             = 22
    - org.gradle.libraryelements         = composed-jar
    - org.gradle.usage                   = java-api
    - org.jetbrains.kotlin.platform.type = jvm
Artifacts
    - build/libs/subpr.jar (artifactType = jar)
```

Here is proof that it works (notice the fake build number, it is from my local maven, also kotlin plugin is commented out):
![image](https://github.com/user-attachments/assets/53b1d2d7-3a01-497a-9119-845b29104a7a)

Now `org.jetbrains:annotations:26.0.1` is available and `org.apache.commons:commons-lang3:3.5` is not, like it should be.

## Related Issue

#1799

## Motivation and Context

It was broken.

## How Has This Been Tested

So far only manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CONTRIBUTING.md) document.
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ x] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CHANGELOG.md).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
