### PR TITLE
Using POST /api/plugins endpoint instead of POST /api/ij-plugins/upload endpoint in publishPlugin() task for IDE Services uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Move `localPlatformArtifacts()` to the top of the `defaultRepositories()` list. 
 - Make IntelliJ Platform dependencies available to `testImplementation` by default to avoid mutating tests classpath
 - For running testing, use test sandbox instead of compiled classes from `build/classes` directory 
+- Updated the `publishPlugin()` task to use IDE Services’ new `POST /api/plugins` API when configured to publish to the IDE Services plugin repository, replacing the deprecated `POST /api/ij-plugins/upload` endpoint
 
 ### Fixed
 

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/utils/IdeServicesPluginRepositoryService.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/utils/IdeServicesPluginRepositoryService.kt
@@ -14,7 +14,7 @@ import retrofit2.http.Part
 interface IdeServicesPluginRepositoryService : PluginRepositoryService {
 
     @Multipart
-    @POST("/api/ij-plugins/upload")
+    @POST("/api/plugins")
     override fun uploadById(
         @Part("pluginId") pluginId: Int,
         @Part("channel") channel: RequestBody?,
@@ -24,7 +24,7 @@ interface IdeServicesPluginRepositoryService : PluginRepositoryService {
     ): Call<PluginUpdateBean>
 
     @Multipart
-    @POST("/api/ij-plugins/upload")
+    @POST("/api/plugins")
     override fun uploadByStringId(
         @Part("xmlId") pluginXmlId: RequestBody,
         @Part("channel") channel: RequestBody?,


### PR DESCRIPTION
# Pull Request Details

## Description

The purpose of this PR is to migrate the `publishPlugin()` from using the deprecated `POST /api/ij-plugins/upload` endpoint to the new path, `POST /api/plugins`. These two endpoints current share the same exact interface, so only the path needs to change.

## Motivation and Context

IDE Services will be removing this deprecated endpoint in a future release.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html).
- [ ] I have updated the documentation accordingly.
- [x] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CHANGELOG.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
