### PR TITLE
Suppress plugin problems for bundled or 3rd party plugins

### DIFF
--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/artifacts/transform/CollectorTransformer.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/artifacts/transform/CollectorTransformer.kt
@@ -72,7 +72,7 @@ abstract class CollectorTransformer : TransformAction<CollectorTransformer.Param
             val productInfo = parameters.intellijPlatform.platformPath().productInfo()
             val plugin by lazy {
                 val pluginPath = path.resolvePluginPath()
-                manager.safelyCreatePlugin(pluginPath).getOrThrow()
+                manager.safelyCreatePlugin(pluginPath, suppressPluginProblems = true).getOrThrow()
             }
 
             val isIntelliJPlatform = path == parameters.intellijPlatform.platformPath()

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformDependenciesHelper.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformDependenciesHelper.kt
@@ -889,7 +889,7 @@ class IntelliJPlatformDependenciesHelper(
                 artifactPath.isDirectory() -> artifactPath.resolvePluginPath()
                 else -> artifactPath
             }
-            pluginManager.safelyCreatePlugin(pluginPath).getOrThrow()
+            pluginManager.safelyCreatePlugin(pluginPath, suppressPluginProblems = true).getOrThrow()
         }
 
         // It is crucial to use the IDE type + build number to the version.

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PublishPluginTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PublishPluginTask.kt
@@ -99,7 +99,7 @@ abstract class PublishPluginTask : DefaultTask() {
         }
 
         val path = archiveFile.asPath
-        val plugin = pluginManager.safelyCreatePlugin(path).getOrThrow()
+        val plugin = pluginManager.safelyCreatePlugin(path, suppressPluginProblems = false).getOrThrow()
 
         val pluginId = plugin.pluginId
         channels.get().forEach { channel ->


### PR DESCRIPTION
# Pull Request Details

Multiple 3rd party or bundled plugins fail a standard plugin verification procedure. Relax plugin construction rules for such plugins - in the spirit of Plugin Verifier.

## Description

When constructing plugin, provide a corresponding instance of `PluginCreationResultResolver`:

- standard when creating the non-bundled plugin
- remapping resolved that suppressed particular plugin problems for JetBrains-originating plugins.

## Motivation and Context

Some plugins cannot be used as a dependency due to their plugin descriptor issues. One example is a Database plugin.
Such plugin is a bundled one, so no issues should arise - a `PluginCreationResultResolver` usually ignores such errors.

## How Has This Been Tested

- Tested integration with Plugin Template.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ ] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CHANGELOG.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
