### PR TITLE
Add required modules of a plugin to the classpath automatically when 'bundledPlugins' is used (#1883)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Fixed the broken path resolution in the `bundledLibrary` helper and the `TestFrameworkType.Bundled` test framework
+- Fixed configuring dependencies on plugins with required content modules (#1883)
 
 ## [2.2.1] - 2025-01-21
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # libraries
 annotations = "26.0.2"
-intellijStructure = "3.294"
+intellijStructure = "3.296"
 intellijPluginRepositoryRestClient = "2.0.45"
 kotlinxSerializationJson = "1.8.0"
 okio = "1.17.6"

--- a/src/integrationTest/kotlin/org/jetbrains/intellij/platform/gradle/DependenciesValidationIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/jetbrains/intellij/platform/gradle/DependenciesValidationIntegrationTest.kt
@@ -295,17 +295,31 @@ class IntelliJPlatformDependencyValidationIntegrationTest : IntelliJPlatformInte
                 |    |              |         +--- bundledPlugin:com.intellij.java:IC-243.21565.193
                 |    |              |         |    +--- bundledPlugin:com.intellij.copyright:IC-243.21565.193 (*)
                 |    |              |         |    +--- bundledPlugin:com.intellij.platform.images:IC-243.21565.193
+                |    |              |         |    +--- bundledPlugin:training:IC-243.21565.193
+                |    |              |         |    |    +--- bundledModule:intellij.platform.tips:IC-243.21565.193
+                |    |              |         |    |    +--- bundledModule:intellij.platform.lvcs.impl:IC-243.21565.193
+                |    |              |         |    |    |    \--- bundledModule:intellij.platform.vcs.impl:IC-243.21565.193 (*)
+                |    |              |         |    |    +--- bundledPlugin:Git4Idea:IC-243.21565.193 (*)
+                |    |              |         |    |    +--- bundledModule:intellij.platform.ide.newUiOnboarding:IC-243.21565.193
+                |    |              |         |    |    \--- bundledModule:intellij.platform.ide.newUsersOnboarding:IC-243.21565.193
+                |    |              |         |    |         +--- bundledModule:intellij.platform.ide.newUiOnboarding:IC-243.21565.193
+                |    |              |         |    |         \--- bundledModule:intellij.platform.experiment:IC-243.21565.193
                 |    |              |         |    +--- bundledModule:intellij.performanceTesting.vcs:IC-243.21565.193
                 |    |              |         |    |    +--- bundledModule:intellij.platform.vcs.impl:IC-243.21565.193 (*)
                 |    |              |         |    |    \--- bundledModule:intellij.platform.vcs.log.impl:IC-243.21565.193 (*)
                 |    |              |         |    +--- bundledPlugin:com.jetbrains.performancePlugin:IC-243.21565.193 (*)
+                |    |              |         |    +--- bundledModule:intellij.platform.vcs.impl:IC-243.21565.193 (*)
                 |    |              |         |    \--- bundledPlugin:org.jetbrains.plugins.terminal:IC-243.21565.193 (*)
                 |    |              |         +--- bundledPlugin:com.intellij.modules.json:IC-243.21565.193
                 |    |              |         +--- bundledPlugin:org.intellij.plugins.markdown:IC-243.21565.193 (*)
                 |    |              |         +--- bundledPlugin:com.intellij.properties:IC-243.21565.193
                 |    |              |         |    \--- bundledPlugin:com.intellij.copyright:IC-243.21565.193 (*)
                 |    |              |         \--- bundledPlugin:org.jetbrains.plugins.yaml:IC-243.21565.193 (*)
-                |    |              \--- bundledPlugin:com.intellij.platform.images:IC-243.21565.193
+                |    |              +--- bundledPlugin:com.intellij.platform.images:IC-243.21565.193
+                |    |              \--- bundledModule:intellij.platform.compose:IC-243.21565.193
+                |    |                   +--- bundledModule:intellij.libraries.compose.desktop:IC-243.21565.193
+                |    |                   |    \--- bundledModule:intellij.libraries.skiko:IC-243.21565.193
+                |    |                   \--- bundledModule:intellij.libraries.skiko:IC-243.21565.193
                 |    \--- bundledModule:intellij.platform.coverage:IC-243.21565.193
                 |         \--- bundledModule:intellij.platform.coverage.agent:IC-243.21565.193
                 \--- idea:ideaIC:2024.3
@@ -340,8 +354,14 @@ class IntelliJPlatformDependencyValidationIntegrationTest : IntelliJPlatformInte
         build(DEPENDENCIES) {
             assertContains(
                 """
-                |    +--- bundledModule:intellij.platform.coverage:IC-243.21565.193
-                |    |    \--- bundledModule:intellij.platform.coverage.agent:IC-243.21565.193
+                +--- bundledModule:intellij.platform.coverage:IC-243.21565.193 (*)
+                """.trimIndent(),
+                output,
+            )
+            assertContains(
+                """
+                |    |    |    |    |    \--- bundledModule:intellij.platform.coverage:IC-243.21565.193
+                |    |    |    |    |         \--- bundledModule:intellij.platform.coverage.agent:IC-243.21565.193
                 """.trimIndent(),
                 output,
             )

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformDependenciesHelper.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformDependenciesHelper.kt
@@ -811,9 +811,12 @@ class IntelliJPlatformDependenciesHelper(
         val id = requireNotNull(pluginId)
         val version = ide.version.toString()
 
-        return dependencies
+        val pluginWithRequiredModules =
+            sequenceOf(this) + modulesDescriptors.asSequence().filter { it.loadingRule.required }.map { it.module }
+        
+        return pluginWithRequiredModules.flatMap { it.dependencies.asSequence() }
             .mapNotNull { ide.findPluginById(it.id) }
-            .map {
+            .mapTo(ArrayList()) {
                 val name = requireNotNull(it.pluginId)
                 val group = when {
                     it is IdeModule -> Dependencies.BUNDLED_MODULE_GROUP


### PR DESCRIPTION
A content module registered as 'required' or 'embedded' in the plugin descriptor is guaranteed to be loaded if the plugin itself is loaded. Since 'depends' tag adds classloaders from all content modules as parent classloaders, references to classes from such modules will be resolved at runtime.

## Related Issue

#1883

## Motivation and Context

To fix #1883.

## How Has This Been Tested

I tested it manually with dependency on YAML plugin in 251.20015.29-EAP-SNAPSHOT build. Not sure how to create a proper automatic test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html).
- [ ] I have updated the documentation accordingly.
- [x] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CHANGELOG.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
