### PR TITLE
Update verification notes on until-build usage

### DIFF
--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/VerifyPluginProjectConfigurationTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/VerifyPluginProjectConfigurationTask.kt
@@ -122,7 +122,7 @@ abstract class VerifyPluginProjectConfigurationTask : DefaultTask(), IntelliJPla
                             yield("The since-build='$sinceBuild' is lower than the target IntelliJ Platform major version: '${platformBuild.major}'.")
                         }
                         if (sinceBuild.major >= 243 && file.parse { ideaVersion.untilBuild != null }) {
-                            yield("The until-build property is ignored for IntelliJ Platform version 243 or higher.")
+                            yield("The until-build property is not recommended for use. Consider using empty until-build for future plugin versions, so users can use your plugin when they update IDE to the latest version.")
                         }
                         if (sinceBuildJavaVersion < targetCompatibilityJavaVersion) {
                             yield("The Java configuration specifies targetCompatibility=$targetCompatibilityJavaVersion but since-build='$sinceBuild' property requires targetCompatibility='$sinceBuildJavaVersion'.")

--- a/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/VerifyPluginProjectConfigurationTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/VerifyPluginProjectConfigurationTaskTest.kt
@@ -329,7 +329,7 @@ class VerifyPluginProjectConfigurationTaskTest : IntelliJPluginTestBase() {
     }
 
     @Test
-    fun `report ignored until-build for version 243 or higher`() {
+    fun `report used until-build`() {
         buildFile write //language=kotlin
                 """
                 intellijPlatform {
@@ -355,7 +355,7 @@ class VerifyPluginProjectConfigurationTaskTest : IntelliJPluginTestBase() {
         build(Tasks.VERIFY_PLUGIN_PROJECT_CONFIGURATION) {
             assertContains(HEADER, output)
             assertContains(
-                "- The until-build property is ignored for IntelliJ Platform version 243 or higher.", output
+                "- The until-build property is not recommended for use. Consider using empty until-build for future plugin versions, so users can use your plugin when they update IDE to the latest version.", output
             )
         }
     }


### PR DESCRIPTION
# Pull Request Details

Here we clarify until-build usage warning

## Description

Here we clarify until-build usage warning

## Related Issue

https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1955

## Motivation and Context

We want to discourage use of until-build in plugins.

## Types of changes

- [X] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ ] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CHANGELOG.md).
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
