### PR TITLE
Ensure artifact transform failures are propagated

### DIFF
--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/artifacts/transform/CollectorTransformer.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/artifacts/transform/CollectorTransformer.kt
@@ -95,7 +95,7 @@ abstract class CollectorTransformer : TransformAction<TransformParameters.None> 
             }
         }.onFailure {
             log.error("${javaClass.canonicalName} execution failed.", it)
-        }
+        }.getOrThrow()
     }
 
     companion object {

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/artifacts/transform/ExtractorTransformer.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/artifacts/transform/ExtractorTransformer.kt
@@ -51,7 +51,7 @@ abstract class ExtractorTransformer : TransformAction<ExtractorTransformer.Param
             parameters.extractorService.get().extract(path, targetDirectory)
         }.onFailure {
             log.error("${javaClass.canonicalName} execution failed.", it)
-        }
+        }.getOrThrow()
     }
 
     companion object {

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/artifacts/transform/LocalPluginsNormalizationTransformer.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/artifacts/transform/LocalPluginsNormalizationTransformer.kt
@@ -63,7 +63,7 @@ abstract class LocalPluginsNormalizationTransformers @Inject constructor(
             }
         }.onFailure {
             log.error("${javaClass.canonicalName} execution failed.", it)
-        }
+        }.getOrThrow()
     }
 
     companion object {


### PR DESCRIPTION
# Pull Request Details

In case an artifact transform doesn't fail (aka throw a failure), Gradle will assume that it passed and never re-run it. The artifact transforms in this plugin swallow all exceptions, essentially causing builds to get into a failing state and making them hard to recover from that state.

This change makes sure we throw the exception when an artifact transform fails, so Gradle will re-run the artifact transform next time.

## Description

## Related Issue

Aims to fix https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1981

## Motivation and Context

## How Has This Been Tested

This is hard to test, since the problem only happens sporadically.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ ] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CHANGELOG.md).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
