### PR TITLE
Integrated Gradle's Reporting API to VerifyPluginProjectConfigurationTask

### DIFF
--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/reports/VerifyPluginConfigurationReports.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/reports/VerifyPluginConfigurationReports.kt
@@ -1,0 +1,60 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+
+package org.jetbrains.intellij.platform.gradle.reports
+
+import org.gradle.api.*
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.reporting.ReportContainer
+import org.gradle.api.reporting.SingleFileReport
+import org.gradle.api.reporting.internal.DefaultReportContainer
+import org.gradle.api.reporting.internal.DefaultSingleFileReport
+import org.gradle.api.reporting.internal.DelegatingReportContainer
+import org.gradle.api.tasks.Nested
+import org.jetbrains.kotlin.com.google.common.collect.ImmutableList
+import javax.inject.Inject
+
+/**
+ * Provides a container for the output reports of verifying the plugin configuration.
+ *
+ * @param owner The entity responsible for these reports, typically the associated task.
+ * @param objectFactory Used to instantiate and manage report objects.
+ * @see VerifyPluginConfigurationReports
+ * @see DelegatingReportContainer
+ * @see DefaultReportContainer
+ * @see DefaultSingleFileReport
+ */
+open class VerifyPluginConfigurationReportsImpl @Inject constructor(
+    owner: Describable,
+    objectFactory: ObjectFactory,
+) : DelegatingReportContainer<SingleFileReport>(
+    DefaultReportContainer.create(
+        objectFactory,
+        SingleFileReport::class.java
+    ) { factory ->
+        val list: Collection<SingleFileReport> = ImmutableList.of(
+            factory.instantiateReport(DefaultSingleFileReport::class.java, "txt", owner)
+        )
+
+        list
+    }
+
+), VerifyPluginConfigurationReports {
+
+    override val txt: SingleFileReport
+        get() = getByName("txt")
+}
+
+/**
+ * Represents a container for output reports of verifying the plugin configuration.
+ *
+ * Implementations are responsible for supplying the actual report instances.
+ *
+ * Typical usage is to access the desired report format for further configuration or output handling.
+ * @see ReportContainer
+ * @see SingleFileReport
+ * @see org.gradle.api.reporting.Reporting
+ */
+interface VerifyPluginConfigurationReports: ReportContainer<SingleFileReport> {
+    @get:Nested
+    val txt: SingleFileReport
+}


### PR DESCRIPTION
# Pull Request Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
As part of GSOC 2025, the VerifyPluginProjectConfigurationTask was updated to integrate Gradle's Reporting API to explore creating and configuring reports for tasks in a standardized manner.

## How Has This Been Tested

The output of  VerifyPluginProjectConfigurationTask before implementation was compared with the output post-implementation of the Reporting API

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ ] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CHANGELOG.md).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
