### PR TITLE
Added the `expandUserHome` function for correct expanding of `~` in paths

### DIFF
--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/GradleProperties.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/GradleProperties.kt
@@ -17,6 +17,7 @@ import org.jetbrains.intellij.platform.gradle.tasks.BuildSearchableOptionsTask
 import org.jetbrains.intellij.platform.gradle.tasks.InitializeIntelliJPlatformPluginTask
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginProjectConfigurationTask
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
+import org.jetbrains.intellij.platform.gradle.utils.FileUtils
 import org.jetbrains.intellij.platform.gradle.utils.Logger
 import java.nio.file.Path
 import kotlin.io.path.absolute
@@ -218,7 +219,6 @@ internal fun ProviderFactory.intellijPlatformIdesCachePath(rootProjectDirectory:
 internal fun Provider<String>.resolvePath() = map {
     when {
         it.isBlank() -> null
-        else -> Path.of(it.replaceFirst("^~".toRegex(), System.getProperty("user.home")))
-            .createDirectories().absolute()
+        else -> Path.of(FileUtils.expandUserHome(it)).createDirectories().absolute()
     }
 }

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/utils/FileUtils.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/utils/FileUtils.kt
@@ -1,0 +1,17 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+
+package org.jetbrains.intellij.platform.gradle.utils
+
+object FileUtils {
+    fun expandUserHome(path: String): String {
+        if (path == "~") {
+            return System.getProperty("user.home")
+        }
+
+        if (path.startsWith("~/") || path.startsWith("~\\")) {
+            return System.getProperty("user.home") + path.substring(1)
+        }
+
+        return path
+    }
+}


### PR DESCRIPTION
# Pull Request Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed ambiguous behavior when expanding `~` in paths. I did the same as in `IntelliJ Platform`.

## Related Issue

#2011, #2012

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Expand paths: `~.intellijPlatform`

### Before

```
$USER_FOLDER.intellijPlatform
```

#### Afrer

```
~.intellijPlatform
```

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ ] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CHANGELOG.md).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
