### PR TITLE
Add native plugin distribution variants

### DIFF
--- a/.github/workflows/reusable-integrationTests.yml
+++ b/.github/workflows/reusable-integrationTests.yml
@@ -22,7 +22,7 @@ jobs:
         gradleVersion:
           - "9.0.0"
           - "9.6.1"
-          - "nightly"
+#          - "nightly"
         os:
           - windows-latest
           - ubuntu-latest

--- a/.github/workflows/reusable-unitTests.yml
+++ b/.github/workflows/reusable-unitTests.yml
@@ -20,7 +20,7 @@ jobs:
         gradleVersion:
           - "9.0.0"
           - "9.6.1"
-          - "nightly"
+#          - "nightly"
         os:
           - windows-latest
           - ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Add `intellijPlatform.nativeVariants` DSL and `buildPluginVariants` tasks for creating Linux, macOS, and Windows plugin distributions targeting `x86_64` and `arm64` architectures.
 - Add `testFrameworks()` dependency helpers for configuring multiple `TestFrameworkType` values in one call JetBrains/intellij-platform-gradle-plugin#2194
 - Expand `TestFrameworkType.Plugin` with IJent, ML completion, navigation bar, Python, RD client, Rider, and statistics test frameworks.
 - Add sandbox-specific runtime classpath configurations for applying dependency exclusions to every `PrepareSandboxTask` without changing project compile or test classpaths JetBrains/intellij-platform-gradle-plugin#2177

--- a/api/IntelliJPlatformGradlePlugin.api
+++ b/api/IntelliJPlatformGradlePlugin.api
@@ -157,6 +157,7 @@ public final class org/jetbrains/intellij/platform/gradle/Constants$Extensions {
 	public static final field INSTANCE Lorg/jetbrains/intellij/platform/gradle/Constants$Extensions;
 	public static final field INTELLIJ_PLATFORM Ljava/lang/String;
 	public static final field INTELLIJ_PLATFORM_TESTING Ljava/lang/String;
+	public static final field NATIVE_VARIANTS Ljava/lang/String;
 	public static final field PLUGINS Ljava/lang/String;
 	public static final field PLUGIN_CONFIGURATION Ljava/lang/String;
 	public static final field PLUGIN_VERIFICATION Ljava/lang/String;
@@ -232,6 +233,7 @@ public final class org/jetbrains/intellij/platform/gradle/Constants$Sandbox$Plug
 
 public final class org/jetbrains/intellij/platform/gradle/Constants$Tasks {
 	public static final field BUILD_PLUGIN Ljava/lang/String;
+	public static final field BUILD_PLUGIN_VARIANTS Ljava/lang/String;
 	public static final field BUILD_SEARCHABLE_OPTIONS Ljava/lang/String;
 	public static final field CLEAN_SANDBOX Ljava/lang/String;
 	public static final field COMPOSED_JAR Ljava/lang/String;
@@ -247,6 +249,7 @@ public final class org/jetbrains/intellij/platform/gradle/Constants$Tasks {
 	public static final field JAR_SEARCHABLE_OPTIONS Ljava/lang/String;
 	public static final field PATCH_PLUGIN_XML Ljava/lang/String;
 	public static final field PREPARE_JAR_SEARCHABLE_OPTIONS Ljava/lang/String;
+	public static final field PREPARE_PLUGIN_VARIANT Ljava/lang/String;
 	public static final field PREPARE_SANDBOX Ljava/lang/String;
 	public static final field PREPARE_TEST Ljava/lang/String;
 	public static final field PREPARE_TEST_IDE_PERFORMANCE_SANDBOX Ljava/lang/String;
@@ -566,6 +569,23 @@ public final class org/jetbrains/intellij/platform/gradle/TestFrameworkType$UiUt
 
 public final class org/jetbrains/intellij/platform/gradle/TestFrameworkType$UiUtil$Jupyter : org/jetbrains/intellij/platform/gradle/TestFrameworkType {
 	public static final field INSTANCE Lorg/jetbrains/intellij/platform/gradle/TestFrameworkType$UiUtil$Jupyter;
+}
+
+public final class org/jetbrains/intellij/platform/gradle/Variant {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/intellij/platform/gradle/Variant;
+	public static synthetic fun copy$default (Lorg/jetbrains/intellij/platform/gradle/Variant;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/intellij/platform/gradle/Variant;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArch ()Ljava/lang/String;
+	public final fun getOs ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/intellij/platform/gradle/VariantKt {
+	public static final fun getVariants ()Ljava/util/List;
 }
 
 public final class org/jetbrains/intellij/platform/gradle/argumentProviders/ComposeHotReloadArgumentProvider : org/gradle/process/CommandLineArgumentProvider {
@@ -969,13 +989,14 @@ public abstract class org/jetbrains/intellij/platform/gradle/extensions/IntelliJ
 
 public abstract class org/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension : org/gradle/api/plugins/ExtensionAware {
 	public static final field Companion Lorg/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension$Companion;
-	public fun <init> (Lorg/gradle/api/artifacts/ConfigurationContainer;Lorg/gradle/api/provider/ProviderFactory;Ljava/nio/file/Path;)V
+	public fun <init> (Lorg/gradle/api/artifacts/ConfigurationContainer;Lorg/gradle/api/provider/ProviderFactory;)V
 	public final fun caching (Lgroovy/lang/Closure;)V
 	public final fun caching (Lorg/gradle/api/Action;)V
 	public abstract fun getAutoReload ()Lorg/gradle/api/provider/Property;
 	public abstract fun getBuildSearchableOptions ()Lorg/gradle/api/provider/Property;
 	public final fun getCaching ()Lorg/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension$Caching;
 	public abstract fun getInstrumentCode ()Lorg/gradle/api/provider/Property;
+	public final fun getNativeVariants ()Lorg/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension$NativeVariants;
 	public final fun getPlatformPath ()Ljava/nio/file/Path;
 	public final fun getPluginConfiguration ()Lorg/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension$PluginConfiguration;
 	public abstract fun getPluginInstallationTarget ()Lorg/gradle/api/provider/Property;
@@ -987,6 +1008,8 @@ public abstract class org/jetbrains/intellij/platform/gradle/extensions/IntelliJ
 	public final fun getSigning ()Lorg/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension$Signing;
 	public abstract fun getSplitMode ()Lorg/gradle/api/provider/Property;
 	public abstract fun getSplitModeTarget ()Lorg/gradle/api/provider/Property;
+	public final fun nativeVariants (Lgroovy/lang/Closure;)V
+	public final fun nativeVariants (Lorg/gradle/api/Action;)V
 	public final fun pluginConfiguration (Lgroovy/lang/Closure;)V
 	public final fun pluginConfiguration (Lorg/gradle/api/Action;)V
 	public final fun pluginVerification (Lgroovy/lang/Closure;)V
@@ -1026,6 +1049,32 @@ public final class org/jetbrains/intellij/platform/gradle/extensions/IntelliJPla
 public final class org/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension$Companion : org/jetbrains/intellij/platform/gradle/extensions/Registrable {
 	public synthetic fun register (Lorg/gradle/api/Project;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun register (Lorg/gradle/api/Project;Ljava/lang/Object;)Lorg/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension;
+}
+
+public abstract class org/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension$NativeVariants : org/gradle/api/plugins/ExtensionAware {
+	public static final field Companion Lorg/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension$NativeVariants$Companion;
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public abstract fun getEnabled ()Lorg/gradle/api/provider/Property;
+	public final fun getLinux ()Lorg/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension$NativeVariants$Platform;
+	public final fun getMac ()Lorg/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension$NativeVariants$Platform;
+	public final fun getWindows ()Lorg/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension$NativeVariants$Platform;
+	public final fun linux (Lgroovy/lang/Closure;)V
+	public final fun linux (Lorg/gradle/api/Action;)V
+	public final fun mac (Lgroovy/lang/Closure;)V
+	public final fun mac (Lorg/gradle/api/Action;)V
+	public final fun windows (Lgroovy/lang/Closure;)V
+	public final fun windows (Lorg/gradle/api/Action;)V
+}
+
+public final class org/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension$NativeVariants$Companion : org/jetbrains/intellij/platform/gradle/extensions/Registrable {
+	public synthetic fun register (Lorg/gradle/api/Project;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun register (Lorg/gradle/api/Project;Ljava/lang/Object;)Lorg/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension$NativeVariants;
+}
+
+public abstract class org/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension$NativeVariants$Platform {
+	public fun <init> ()V
+	public abstract fun getArm64 ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getX86_64 ()Lorg/gradle/api/file/ConfigurableFileCollection;
 }
 
 public abstract interface class org/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension$PluginConfiguration : org/gradle/api/plugins/ExtensionAware {
@@ -2850,6 +2899,15 @@ public final class org/jetbrains/intellij/platform/gradle/tasks/BuildPluginTask$
 	public fun register (Lorg/gradle/api/Project;)V
 }
 
+public abstract class org/jetbrains/intellij/platform/gradle/tasks/BuildPluginVariantsTask : org/gradle/api/DefaultTask {
+	public static final field Companion Lorg/jetbrains/intellij/platform/gradle/tasks/BuildPluginVariantsTask$Companion;
+	public fun <init> ()V
+}
+
+public final class org/jetbrains/intellij/platform/gradle/tasks/BuildPluginVariantsTask$Companion : org/jetbrains/intellij/platform/gradle/tasks/Registrable {
+	public fun register (Lorg/gradle/api/Project;)V
+}
+
 public abstract class org/jetbrains/intellij/platform/gradle/tasks/BuildSearchableOptionsTask : org/gradle/api/tasks/JavaExec, org/jetbrains/intellij/platform/gradle/tasks/aware/RunnableIdeAware {
 	public static final field Companion Lorg/jetbrains/intellij/platform/gradle/tasks/BuildSearchableOptionsTask$Companion;
 	public fun <init> ()V
@@ -3051,6 +3109,21 @@ public abstract class org/jetbrains/intellij/platform/gradle/tasks/PrepareJarSea
 }
 
 public final class org/jetbrains/intellij/platform/gradle/tasks/PrepareJarSearchableOptionsTask$Companion : org/jetbrains/intellij/platform/gradle/tasks/Registrable {
+	public fun register (Lorg/gradle/api/Project;)V
+}
+
+public abstract class org/jetbrains/intellij/platform/gradle/tasks/PreparePluginVariantTask : org/gradle/api/DefaultTask {
+	public static final field Companion Lorg/jetbrains/intellij/platform/gradle/tasks/PreparePluginVariantTask$Companion;
+	public fun <init> ()V
+	public abstract fun getArchitecture ()Lorg/gradle/api/provider/Property;
+	public abstract fun getInputJar ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getOperatingSystem ()Lorg/gradle/api/provider/Property;
+	public abstract fun getOutputDirectory ()Lorg/gradle/api/file/DirectoryProperty;
+	public abstract fun getPluginVersion ()Lorg/gradle/api/provider/Property;
+	public final fun preparePluginVariant ()V
+}
+
+public final class org/jetbrains/intellij/platform/gradle/tasks/PreparePluginVariantTask$Companion : org/jetbrains/intellij/platform/gradle/tasks/Registrable {
 	public fun register (Lorg/gradle/api/Project;)V
 }
 

--- a/api/IntelliJPlatformGradlePlugin.api
+++ b/api/IntelliJPlatformGradlePlugin.api
@@ -2902,6 +2902,7 @@ public final class org/jetbrains/intellij/platform/gradle/tasks/BuildPluginTask$
 public abstract class org/jetbrains/intellij/platform/gradle/tasks/BuildPluginVariantsTask : org/gradle/api/DefaultTask {
 	public static final field Companion Lorg/jetbrains/intellij/platform/gradle/tasks/BuildPluginVariantsTask$Companion;
 	public fun <init> ()V
+	public abstract fun getArchiveFiles ()Lorg/gradle/api/file/ConfigurableFileCollection;
 }
 
 public final class org/jetbrains/intellij/platform/gradle/tasks/BuildPluginVariantsTask$Companion : org/jetbrains/intellij/platform/gradle/tasks/Registrable {
@@ -3213,7 +3214,7 @@ public final class org/jetbrains/intellij/platform/gradle/tasks/PrintProductsRel
 public abstract class org/jetbrains/intellij/platform/gradle/tasks/PublishPluginTask : org/gradle/api/DefaultTask {
 	public static final field Companion Lorg/jetbrains/intellij/platform/gradle/tasks/PublishPluginTask$Companion;
 	public fun <init> ()V
-	public abstract fun getArchiveFile ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getArchiveFiles ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getChannels ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getHidden ()Lorg/gradle/api/provider/Property;
 	public abstract fun getHost ()Lorg/gradle/api/provider/Property;

--- a/src/integrationTest/kotlin/org/jetbrains/intellij/platform/gradle/SandboxIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/jetbrains/intellij/platform/gradle/SandboxIntegrationTest.kt
@@ -100,21 +100,20 @@ class SandboxIntegrationTest : IntelliJPlatformIntegrationTestBase(
     fun `create sandbox in a custom directory within the common sandbox container`() {
         buildFile write //language=kotlin
                 """
-                tasks {
-                    prepareSandbox {
-                        sandboxDirectory = intellijPlatform.sandboxContainer.map { it.dir("custom-directory") }
-                    }
+                tasks.named<org.jetbrains.intellij.platform.gradle.tasks.PrepareSandboxTask>("${Tasks.PREPARE_SANDBOX}_${Tasks.RUN_IDE}") {
+                    sandboxDirectory = intellijPlatform.sandboxContainer.map { it.dir("custom-directory") }
                 }
                 """.trimIndent()
 
         build(Tasks.RUN_IDE, projectProperties = defaultProjectProperties) {
             val sandbox = sandboxDirectory.resolve("custom-directory")
+            val suffix = "_${Tasks.RUN_IDE}"
 
             assertExists(sandbox)
-            assertExists(sandbox.resolve(Sandbox.CONFIG))
-            assertExists(sandbox.resolve(Sandbox.LOG))
-            assertExists(sandbox.resolve(Sandbox.PLUGINS))
-            assertExists(sandbox.resolve(Sandbox.SYSTEM))
+            assertExists(sandbox.resolve(Sandbox.CONFIG + suffix))
+            assertExists(sandbox.resolve(Sandbox.LOG + suffix))
+            assertExists(sandbox.resolve(Sandbox.PLUGINS + suffix))
+            assertExists(sandbox.resolve(Sandbox.SYSTEM + suffix))
         }
     }
 

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/Constants.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/Constants.kt
@@ -65,6 +65,7 @@ object Constants {
         const val IDEA_VERSION = "ideaVersion"
         const val INTELLIJ_PLATFORM = "intellijPlatform"
         const val INTELLIJ_PLATFORM_TESTING = "intellijPlatformTesting"
+        const val NATIVE_VARIANTS = "nativeVariants"
         const val PLUGIN_CONFIGURATION = "pluginConfiguration"
         const val PLUGIN_VERIFICATION = "pluginVerification"
         const val PLUGINS = "plugins"
@@ -193,6 +194,7 @@ object Constants {
 
     object Tasks {
         const val BUILD_PLUGIN = "buildPlugin"
+        const val BUILD_PLUGIN_VARIANTS = "buildPluginVariants"
         const val BUILD_SEARCHABLE_OPTIONS = "buildSearchableOptions"
         const val CLEAN_SANDBOX = "cleanSandbox"
         const val COMPOSED_JAR = "composedJar"
@@ -207,6 +209,7 @@ object Constants {
         const val JAR_SEARCHABLE_OPTIONS = "jarSearchableOptions"
         const val PATCH_PLUGIN_XML = "patchPluginXml"
         const val PREPARE_JAR_SEARCHABLE_OPTIONS = "prepareJarSearchableOptions"
+        const val PREPARE_PLUGIN_VARIANT = "preparePluginVariant"
         const val PREPARE_SANDBOX = "prepareSandbox"
         const val PREPARE_TEST = "prepareTest"
         const val PREPARE_TEST_SANDBOX = "prepareTestSandbox"

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/Variant.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/Variant.kt
@@ -1,0 +1,14 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+
+package org.jetbrains.intellij.platform.gradle
+
+data class Variant(val os: String, val arch: String)
+
+val variants = listOf(
+    Variant("linux", "x86_64"),
+    Variant("linux", "arm64"),
+    Variant("mac", "x86_64"),
+    Variant("mac", "arm64"),
+    Variant("windows", "x86_64"),
+    Variant("windows", "arm64")
+)

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/Variant.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/Variant.kt
@@ -2,6 +2,9 @@
 
 package org.jetbrains.intellij.platform.gradle
 
+import org.gradle.api.GradleException
+import org.gradle.api.provider.ProviderFactory
+
 data class Variant(val os: String, val arch: String)
 
 val variants = listOf(
@@ -11,4 +14,23 @@ val variants = listOf(
     Variant("mac", "arm64"),
     Variant("windows", "x86_64"),
     Variant("windows", "arm64")
+)
+
+internal fun ProviderFactory.currentVariant() =
+    systemProperty("os.name").zip(systemProperty("os.arch")) { osName, architecture ->
+        currentVariant(osName, architecture)
+    }
+
+internal fun currentVariant(osName: String, architecture: String) = Variant(
+    os = when {
+        osName.contains("linux", ignoreCase = true) -> "linux"
+        osName.contains("mac", ignoreCase = true) || osName.contains("darwin", ignoreCase = true) -> "mac"
+        osName.contains("windows", ignoreCase = true) -> "windows"
+        else -> throw GradleException("Unsupported operating system for native variants: '$osName'.")
+    },
+    arch = when (architecture.lowercase()) {
+        "amd64", "x86_64", "x64" -> "x86_64"
+        "aarch64", "arm64" -> "arm64"
+        else -> throw GradleException("Unsupported architecture for native variants: '$architecture'.")
+    },
 )

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformExtension.kt
@@ -224,6 +224,24 @@ abstract class IntelliJPlatformExtension @Inject constructor(
         action.call()
     }
 
+    val nativeVariants
+        get() = extensions.getByType<NativeVariants>()
+
+    fun nativeVariants(action: Action<in NativeVariants>) {
+        action.execute(nativeVariants)
+    }
+
+    fun nativeVariants(
+        @DelegatesTo(
+            value = NativeVariants::class,
+            strategy = Closure.DELEGATE_FIRST
+        ) action: Closure<*>,
+    ) {
+        action.delegate = nativeVariants
+        action.resolveStrategy = Closure.DELEGATE_FIRST
+        action.call()
+    }
+
     @IntelliJPlatform
     abstract class Caching : ExtensionAware {
 
@@ -1197,6 +1215,80 @@ abstract class IntelliJPlatformExtension @Inject constructor(
                     )
                     teamCityOutputFormat.convention(false)
                     subsystemsToCheck.convention(Subsystems.ALL)
+                }
+        }
+    }
+
+    @IntelliJPlatform
+    abstract class NativeVariants @Inject constructor(
+        objects: ObjectFactory,
+    ) : ExtensionAware {
+
+        val linux = objects.newInstance<Platform>()
+        val mac = objects.newInstance<Platform>()
+        val windows = objects.newInstance<Platform>()
+
+        fun linux(action: Action<in Platform>) {
+            action.execute(linux)
+        }
+
+        fun linux(@DelegatesTo(value = Platform::class, strategy = Closure.DELEGATE_FIRST) action: Closure<*>) {
+            action.delegate = linux
+            action.resolveStrategy = Closure.DELEGATE_FIRST
+            action.call()
+        }
+
+        fun mac(action: Action<in Platform>) {
+            action.execute(mac)
+        }
+
+        fun mac(@DelegatesTo(value = Platform::class, strategy = Closure.DELEGATE_FIRST) action: Closure<*>) {
+            action.delegate = mac
+            action.resolveStrategy = Closure.DELEGATE_FIRST
+            action.call()
+        }
+
+        fun windows(action: Action<in Platform>) {
+            action.execute(windows)
+        }
+
+        fun windows(@DelegatesTo(value = Platform::class, strategy = Closure.DELEGATE_FIRST) action: Closure<*>) {
+            action.delegate = windows
+            action.resolveStrategy = Closure.DELEGATE_FIRST
+            action.call()
+        }
+
+        /**
+         * Publish the plugin update in multiple variants for different OSes and architectures.
+         *
+         * Default value: `false`
+         */
+        abstract val enabled: Property<Boolean>
+
+        internal operator fun get(variant: Variant) = with(variant) {
+            when (os) {
+                "linux" -> linux
+                "mac" -> mac
+                "windows" -> windows
+                else -> error("Unsupported operating system: $os")
+            }.let { platform ->
+                when (arch) {
+                    "x86_64" -> platform.x86_64
+                    "arm64" -> platform.arm64
+                    else -> error("Unsupported architecture: $arch")
+                }
+            }
+        }
+
+        abstract class Platform {
+            abstract val x86_64: ConfigurableFileCollection
+            abstract val arm64: ConfigurableFileCollection
+        }
+
+        companion object : Registrable<NativeVariants> {
+            override fun register(project: Project, target: Any) =
+                target.configureExtension<NativeVariants>(Extensions.NATIVE_VARIANTS) {
+                    enabled.convention(false)
                 }
         }
     }

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformTestingExtension.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/extensions/IntelliJPlatformTestingExtension.kt
@@ -269,6 +269,10 @@ abstract class IntelliJPlatformTestingExtension @Inject constructor(
                 val prepareSandboxTask = project.tasks.register<PrepareSandboxTask>(Tasks.PREPARE_SANDBOX.withSuffix) {
                     group = Plugin.GROUP_NAME
 
+                    if (T::class == RunIdeTask::class) {
+                        includeCurrentNativeVariant()
+                    }
+
                     intelliJPlatformConfiguration = customIntelliJPlatformConfiguration
                     intelliJPlatformPluginConfiguration = customIntellijPlatformTestPluginConfiguration
 

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/plugins/project/IntelliJPlatformBasePlugin.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/plugins/project/IntelliJPlatformBasePlugin.kt
@@ -588,6 +588,7 @@ abstract class IntelliJPlatformBasePlugin : Plugin<Project> {
 
             Signing.register(project, target = intelliJPlatform)
             Publishing.register(project, target = intelliJPlatform)
+            NativeVariants.register(project, target = intelliJPlatform)
         }
 
         IntelliJPlatformDependenciesExtension.register(

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/plugins/project/IntelliJPlatformPlugin.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/plugins/project/IntelliJPlatformPlugin.kt
@@ -44,6 +44,8 @@ abstract class IntelliJPlatformPlugin : Plugin<Project> {
             BuildSearchableOptionsTask,
             PrepareJarSearchableOptionsTask,
             JarSearchableOptionsTask,
+            PreparePluginVariantTask,
+            BuildPluginVariantsTask,
             BuildPluginTask,
 
             // Test

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/BuildPluginTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/BuildPluginTask.kt
@@ -3,6 +3,7 @@
 package org.jetbrains.intellij.platform.gradle.tasks
 
 import org.gradle.api.Project
+import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.kotlin.dsl.get
@@ -44,7 +45,9 @@ abstract class BuildPluginTask : Zip() {
                 from(jarSearchableOptionsTaskProvider) {
                     into(Sandbox.Plugin.LIB)
                 }
-                from(prepareSandboxTaskProvider.map { it.pluginDirectory })
+                from(prepareSandboxTaskProvider.map { it.pluginDirectory }) {
+                    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+                }
                 into(archiveBaseName)
             }
 

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/BuildPluginVariantsTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/BuildPluginVariantsTask.kt
@@ -1,0 +1,59 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+
+package org.jetbrains.intellij.platform.gradle.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.register
+import org.gradle.work.DisableCachingByDefault
+import org.jetbrains.intellij.platform.gradle.Constants.Plugin
+import org.jetbrains.intellij.platform.gradle.Constants.Sandbox
+import org.jetbrains.intellij.platform.gradle.Constants.Tasks
+import org.jetbrains.intellij.platform.gradle.utils.extensionProvider
+import org.jetbrains.intellij.platform.gradle.variants
+
+/**
+ * Builds all enabled OS- and architecture-specific plugin distributions.
+ */
+@DisableCachingByDefault(because = "No output state to track")
+abstract class BuildPluginVariantsTask : DefaultTask() {
+
+    init {
+        group = Plugin.GROUP_NAME
+        description = "Builds all OS- and architecture-specific plugin distributions."
+    }
+
+    companion object : Registrable {
+        override fun register(project: Project) {
+            val nativeVariantsEnabledProvider = project.extensionProvider.flatMap { it.nativeVariants.enabled }
+
+            val variantTaskProviders = variants.map { variant ->
+                val (os, arch) = variant
+                val suffix = "_${os}_$arch"
+                val preparePluginVariantTaskProvider = project.tasks.named<PreparePluginVariantTask>(Tasks.PREPARE_PLUGIN_VARIANT + suffix)
+
+                project.tasks.register<BuildPluginTask>(Tasks.BUILD_PLUGIN_VARIANTS + suffix) {
+                    archiveClassifier.convention("$os-$arch")
+
+                    from(preparePluginVariantTaskProvider.flatMap { it.outputDirectory }) {
+                        into(Sandbox.Plugin.LIB)
+                    }
+                    from(project.extensionProvider.map { it.nativeVariants[variant] })
+
+                    onlyIf("native variants are enabled") {
+                        nativeVariantsEnabledProvider.get()
+                    }
+                }
+            }
+
+            project.registerTask<BuildPluginVariantsTask>(Tasks.BUILD_PLUGIN_VARIANTS, configureWithType = false) {
+                dependsOn(
+                    nativeVariantsEnabledProvider.map { enabled ->
+                        variantTaskProviders.takeIf { enabled }.orEmpty()
+                    }
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/BuildPluginVariantsTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/BuildPluginVariantsTask.kt
@@ -4,6 +4,8 @@ package org.jetbrains.intellij.platform.gradle.tasks
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.tasks.OutputFiles
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
 import org.gradle.work.DisableCachingByDefault
@@ -19,6 +21,9 @@ import org.jetbrains.intellij.platform.gradle.variants
 @DisableCachingByDefault(because = "No output state to track")
 abstract class BuildPluginVariantsTask : DefaultTask() {
 
+    @get:OutputFiles
+    abstract val archiveFiles: ConfigurableFileCollection
+
     init {
         group = Plugin.GROUP_NAME
         description = "Builds all OS- and architecture-specific plugin distributions."
@@ -31,7 +36,8 @@ abstract class BuildPluginVariantsTask : DefaultTask() {
             val variantTaskProviders = variants.map { variant ->
                 val (os, arch) = variant
                 val suffix = "_${os}_$arch"
-                val preparePluginVariantTaskProvider = project.tasks.named<PreparePluginVariantTask>(Tasks.PREPARE_PLUGIN_VARIANT + suffix)
+                val preparePluginVariantTaskProvider =
+                    project.tasks.named<PreparePluginVariantTask>(Tasks.PREPARE_PLUGIN_VARIANT + suffix)
 
                 project.tasks.register<BuildPluginTask>(Tasks.BUILD_PLUGIN_VARIANTS + suffix) {
                     archiveClassifier.convention("$os-$arch")
@@ -48,10 +54,15 @@ abstract class BuildPluginVariantsTask : DefaultTask() {
             }
 
             project.registerTask<BuildPluginVariantsTask>(Tasks.BUILD_PLUGIN_VARIANTS, configureWithType = false) {
+                archiveFiles.from(
+                    variantTaskProviders.map {
+                        it.map { task -> task.archiveFile }
+                    },
+                )
                 dependsOn(
                     nativeVariantsEnabledProvider.map { enabled ->
                         variantTaskProviders.takeIf { enabled }.orEmpty()
-                    }
+                    },
                 )
             }
         }

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PreparePluginVariantTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PreparePluginVariantTask.kt
@@ -1,0 +1,162 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+
+package org.jetbrains.intellij.platform.gradle.tasks
+
+import com.jetbrains.plugin.structure.intellij.utils.JDOMUtil
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.register
+import org.jdom2.Element
+import org.jetbrains.intellij.platform.gradle.Constants.Plugin
+import org.jetbrains.intellij.platform.gradle.Constants.Tasks
+import org.jetbrains.intellij.platform.gradle.models.transformXml
+import org.jetbrains.intellij.platform.gradle.utils.asPath
+import org.jetbrains.intellij.platform.gradle.utils.extensionProvider
+import org.jetbrains.intellij.platform.gradle.variants
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.createDirectories
+import kotlin.io.path.deleteIfExists
+import kotlin.io.path.outputStream
+import kotlin.io.path.readBytes
+
+private const val PLUGIN_XML_PATH = "META-INF/plugin.xml"
+
+/**
+ * Creates an OS- and architecture-specific plugin Jar from the shared composed plugin Jar.
+ */
+@CacheableTask
+abstract class PreparePluginVariantTask : DefaultTask() {
+
+    /**
+     * The shared composed plugin Jar used as the source of the variant.
+     */
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val inputJar: RegularFileProperty
+
+    /**
+     * The plugin version written to the variant's `plugin.xml` file.
+     */
+    @get:Input
+    abstract val pluginVersion: Property<String>
+
+    /**
+     * The operating-system suffix of the required IntelliJ Platform module.
+     */
+    @get:Input
+    abstract val operatingSystem: Property<String>
+
+    /**
+     * The architecture suffix of the required IntelliJ Platform module.
+     */
+    @get:Input
+    abstract val architecture: Property<String>
+
+    /**
+     * The directory containing the variant-specific plugin Jar.
+     */
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    init {
+        group = Plugin.GROUP_NAME
+        description = "Creates an OS- and architecture-specific plugin Jar."
+    }
+
+    @TaskAction
+    fun preparePluginVariant() {
+        val outputPath = outputDirectory.asPath
+            .also { it.toFile().deleteRecursively() }
+            .also { it.createDirectories() }
+            .resolve(inputJar.asPath.fileName)
+        val temporaryPath = outputPath.resolveSibling("${outputPath.fileName}.tmp")
+
+        try {
+            ZipFile(inputJar.asFile.get()).use { input ->
+                ZipOutputStream(temporaryPath.outputStream().buffered()).use { output ->
+                    input.entries().asSequence().forEach { entry ->
+                        output.putNextEntry(ZipEntry(entry.name).apply { time = 0L })
+
+                        if (!entry.isDirectory) {
+                            input.getInputStream(entry).use { content ->
+                                when (entry.name) {
+                                    PLUGIN_XML_PATH -> output.write(patchPluginXml(content.readBytes()))
+                                    else -> content.copyTo(output)
+                                }
+                            }
+                        }
+
+                        output.closeEntry()
+                    }
+                }
+            }
+
+            Files.move(temporaryPath, outputPath, StandardCopyOption.REPLACE_EXISTING)
+        } finally {
+            temporaryPath.deleteIfExists()
+        }
+    }
+
+    private fun patchPluginXml(content: ByteArray): ByteArray {
+        val document = JDOMUtil.loadDocument(content.inputStream())
+        val pluginXml = requireNotNull(document.rootElement.takeIf { it.name == "idea-plugin" }) {
+            "Invalid '$PLUGIN_XML_PATH': '<idea-plugin>' root element was expected."
+        }
+
+        val version = pluginXml.getChild("version") ?: Element("version").also {
+            pluginXml.addContent(0, it)
+        }
+        version.text = pluginVersion.get()
+
+        listOf(
+            "com.intellij.modules.os.${operatingSystem.get()}",
+            "com.intellij.modules.arch.${architecture.get()}",
+        ).forEach { dependency ->
+            if (pluginXml.getChildren("depends").none { it.textTrim == dependency }) {
+                pluginXml.addContent(Element("depends").setText(dependency))
+            }
+        }
+
+        return temporaryDir.toPath()
+            .resolve("plugin.xml")
+            .also { transformXml(document, it) }
+            .readBytes()
+    }
+
+    companion object : Registrable {
+        override fun register(project: Project) {
+            val composedJarTaskProvider = project.tasks.named<ComposedJarTask>(Tasks.COMPOSED_JAR)
+            val pluginVersionProvider = project.extensionProvider.flatMap { it.pluginConfiguration.version }
+            val nativeVariantsEnabledProvider = project.extensionProvider.flatMap { it.nativeVariants.enabled }
+
+            variants.forEach { (os, arch) ->
+                project.tasks.register<PreparePluginVariantTask>("${Tasks.PREPARE_PLUGIN_VARIANT}_${os}_$arch") {
+                    inputJar.convention(composedJarTaskProvider.flatMap { it.archiveFile })
+                    pluginVersion.convention(pluginVersionProvider.map { "$it-$os-$arch" })
+                    operatingSystem.convention(os)
+                    architecture.convention(arch)
+                    outputDirectory.convention(project.layout.buildDirectory.dir("intermediates/pluginVariants/$os-$arch"))
+
+                    onlyIf("native variants are enabled") {
+                        nativeVariantsEnabledProvider.get()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PreparePluginVariantTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PreparePluginVariantTask.kt
@@ -20,6 +20,7 @@ import org.gradle.kotlin.dsl.register
 import org.jdom2.Element
 import org.jetbrains.intellij.platform.gradle.Constants.Plugin
 import org.jetbrains.intellij.platform.gradle.Constants.Tasks
+import org.jetbrains.intellij.platform.gradle.Variant
 import org.jetbrains.intellij.platform.gradle.models.transformXml
 import org.jetbrains.intellij.platform.gradle.utils.asPath
 import org.jetbrains.intellij.platform.gradle.utils.extensionProvider
@@ -139,13 +140,18 @@ abstract class PreparePluginVariantTask : DefaultTask() {
     }
 
     companion object : Registrable {
+        internal fun taskName(variant: Variant) =
+            with(variant) { "${Tasks.PREPARE_PLUGIN_VARIANT}_${os}_$arch" }
+
         override fun register(project: Project) {
             val composedJarTaskProvider = project.tasks.named<ComposedJarTask>(Tasks.COMPOSED_JAR)
             val pluginVersionProvider = project.extensionProvider.flatMap { it.pluginConfiguration.version }
             val nativeVariantsEnabledProvider = project.extensionProvider.flatMap { it.nativeVariants.enabled }
 
-            variants.forEach { (os, arch) ->
-                project.tasks.register<PreparePluginVariantTask>("${Tasks.PREPARE_PLUGIN_VARIANT}_${os}_$arch") {
+            variants.forEach { variant ->
+                val (os, arch) = variant
+
+                project.tasks.register<PreparePluginVariantTask>(taskName(variant)) {
                     inputJar.convention(composedJarTaskProvider.flatMap { it.archiveFile })
                     pluginVersion.convention(pluginVersionProvider.map { "$it-$os-$arch" })
                     operatingSystem.convention(os)

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PrepareSandboxTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PrepareSandboxTask.kt
@@ -24,7 +24,6 @@ import org.jetbrains.intellij.platform.gradle.Constants.Plugin
 import org.jetbrains.intellij.platform.gradle.Constants.Sandbox
 import org.jetbrains.intellij.platform.gradle.Constants.Tasks
 import org.jetbrains.intellij.platform.gradle.currentVariant
-import org.jetbrains.intellij.platform.gradle.variants
 import org.jetbrains.intellij.platform.gradle.extensions.IntelliJPlatformDependenciesExtension
 import org.jetbrains.intellij.platform.gradle.extensions.IntelliJPlatformExtension
 import org.jetbrains.intellij.platform.gradle.extensions.IntelliJPlatformPluginsExtension
@@ -44,9 +43,6 @@ internal fun Project.currentNativeVariantFiles(consumerName: String): CurrentNat
     val nativeVariantsProvider = extensionProvider.map { it.nativeVariants }
     val currentVariantProvider = providers.currentVariant()
     val nativeVariantsEnabledProvider = nativeVariantsProvider.flatMap { it.enabled }
-    val preparePluginVariantTaskProviders = variants.associateWith { variant ->
-        tasks.named<PreparePluginVariantTask>(PreparePluginVariantTask.taskName(variant))
-    }
 
     val emptyFiles = objects.fileCollection()
     val emptyFilesProvider = provider { emptyFiles }
@@ -67,7 +63,9 @@ internal fun Project.currentNativeVariantFiles(consumerName: String): CurrentNat
         nativeVariantsEnabledProvider.flatMap { enabled ->
             when {
                 enabled -> currentVariantProvider.flatMap { variant ->
-                    preparePluginVariantTaskProviders.getValue(variant).flatMap { it.outputDirectory }
+                    tasks
+                        .named<PreparePluginVariantTask>(PreparePluginVariantTask.taskName(variant))
+                        .flatMap { it.outputDirectory }
                 }
 
                 else -> emptyPluginJarDirectoryProvider

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PrepareSandboxTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PrepareSandboxTask.kt
@@ -10,6 +10,7 @@ import org.gradle.api.Project
 import org.gradle.api.file.*
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.*
 import org.gradle.jvm.tasks.Jar
@@ -22,13 +23,64 @@ import org.jetbrains.intellij.platform.gradle.Constants.Configurations
 import org.jetbrains.intellij.platform.gradle.Constants.Plugin
 import org.jetbrains.intellij.platform.gradle.Constants.Sandbox
 import org.jetbrains.intellij.platform.gradle.Constants.Tasks
+import org.jetbrains.intellij.platform.gradle.currentVariant
+import org.jetbrains.intellij.platform.gradle.variants
 import org.jetbrains.intellij.platform.gradle.extensions.IntelliJPlatformDependenciesExtension
 import org.jetbrains.intellij.platform.gradle.extensions.IntelliJPlatformExtension
 import org.jetbrains.intellij.platform.gradle.extensions.IntelliJPlatformPluginsExtension
 import org.jetbrains.intellij.platform.gradle.models.transformXml
 import org.jetbrains.intellij.platform.gradle.tasks.aware.*
 import org.jetbrains.intellij.platform.gradle.utils.*
+import javax.inject.Inject
 import kotlin.io.path.*
+
+internal data class CurrentNativeVariantFiles(
+    val enabled: Provider<Boolean>,
+    val files: ConfigurableFileCollection,
+    val pluginJar: ConfigurableFileCollection,
+)
+
+internal fun Project.currentNativeVariantFiles(consumerName: String): CurrentNativeVariantFiles {
+    val nativeVariantsProvider = extensionProvider.map { it.nativeVariants }
+    val currentVariantProvider = providers.currentVariant()
+    val nativeVariantsEnabledProvider = nativeVariantsProvider.flatMap { it.enabled }
+    val preparePluginVariantTaskProviders = variants.associateWith { variant ->
+        tasks.named<PreparePluginVariantTask>(PreparePluginVariantTask.taskName(variant))
+    }
+
+    val emptyFiles = objects.fileCollection()
+    val emptyFilesProvider = provider { emptyFiles }
+    val nativeVariantFiles = objects.fileCollection().from(
+        nativeVariantsEnabledProvider.flatMap { enabled ->
+            when {
+                enabled -> currentVariantProvider.flatMap { variant ->
+                    nativeVariantsProvider.map { it[variant] }
+                }
+
+                else -> emptyFilesProvider
+            }
+        }
+    )
+
+    val emptyPluginJarDirectoryProvider = layout.buildDirectory.dir("tmp/nativeVariants/empty/$consumerName")
+    val nativeVariantPluginJar = objects.fileCollection().from(
+        nativeVariantsEnabledProvider.flatMap { enabled ->
+            when {
+                enabled -> currentVariantProvider.flatMap { variant ->
+                    preparePluginVariantTaskProviders.getValue(variant).flatMap { it.outputDirectory }
+                }
+
+                else -> emptyPluginJarDirectoryProvider
+            }
+        }
+    )
+
+    return CurrentNativeVariantFiles(
+        enabled = nativeVariantsEnabledProvider,
+        files = nativeVariantFiles,
+        pluginJar = nativeVariantPluginJar,
+    )
+}
 
 /**
  * Prepares a sandbox environment with the plugin and its dependencies installed.
@@ -42,6 +94,13 @@ import kotlin.io.path.*
 @Suppress("KDocUnresolvedReference")
 @DisableCachingByDefault(because = "Not worth caching")
 abstract class PrepareSandboxTask : Sync(), IntelliJPlatformVersionAware, SandboxStructure, SplitModeAware, PluginInstallationTargetAware {
+
+    @get:Inject
+    internal abstract val fileSystemOperations: FileSystemOperations
+
+    private val nativeVariantEnabled = project.objects.property(Boolean::class.java).convention(false)
+    private val nativeVariantFiles = project.objects.fileCollection()
+    private val nativeVariantPluginJar = project.objects.fileCollection()
 
     /**
      * Represents the suffix used i.e., for test-related or custom tasks.
@@ -148,6 +207,7 @@ abstract class PrepareSandboxTask : Sync(), IntelliJPlatformVersionAware, Sandbo
 
         preparePluginDirectories()
         super.copy()
+        copyNativeVariant()
     }
 
     override fun getDestinationDir() = defaultDestinationDirectory.asFile.get()
@@ -255,19 +315,45 @@ abstract class PrepareSandboxTask : Sync(), IntelliJPlatformVersionAware, Sandbo
             ?.forEach { it.deleteRecursively() }
     }
 
+    private fun copyNativeVariant() {
+        if (!nativeVariantEnabled.get()) {
+            return
+        }
+
+        val libDirectory = pluginDirectory.dir(Sandbox.Plugin.LIB)
+
+        pluginDirectory.asPath
+            .resolve(Sandbox.Plugin.LIB)
+            .resolve(pluginJar.asPath.fileName)
+            .deleteIfExists()
+
+        fileSystemOperations.copy {
+            from(nativeVariantFiles)
+            into(pluginDirectory)
+            duplicatesStrategy = DuplicatesStrategy.INCLUDE
+        }
+        fileSystemOperations.copy {
+            from(nativeVariantPluginJar)
+            into(libDirectory)
+            duplicatesStrategy = DuplicatesStrategy.INCLUDE
+        }
+    }
+
     init {
         group = Plugin.GROUP_NAME
         description = "Prepares a sandbox environment with the plugin and its dependencies installed."
         duplicatesStrategy = DuplicatesStrategy.WARN
     }
 
+    internal fun includeCurrentNativeVariant() = with(project.currentNativeVariantFiles(name)) {
+        nativeVariantEnabled.set(enabled)
+        nativeVariantFiles.from(files)
+        nativeVariantPluginJar.from(pluginJar)
+    }
+
     companion object : Registrable {
         override fun register(project: Project) =
-            project.registerTask<PrepareSandboxTask>(
-                Tasks.PREPARE_SANDBOX,
-                Tasks.PREPARE_TEST_SANDBOX,
-                Tasks.PREPARE_TEST_IDE_PERFORMANCE_SANDBOX,
-            ) {
+            project.registerTask<PrepareSandboxTask>(Tasks.PREPARE_SANDBOX) {
                 val composedJarTaskProvider = project.tasks.named<ComposedJarTask>(Tasks.COMPOSED_JAR)
 
                 sandboxSuffix.convention(
@@ -353,8 +439,15 @@ abstract class PrepareSandboxTask : Sync(), IntelliJPlatformVersionAware, Sandbo
                 from(pluginsClasspath)
 
                 inputs.property("instrumentCode", project.extensionProvider.flatMap { it.instrumentCode })
+                inputs.property("nativeVariantEnabled", nativeVariantEnabled)
                 inputs.property("sandboxDirectory", sandboxDirectory.map { it.asPath.pathString })
                 inputs.property("sandboxSuffix", sandboxSuffix)
+                inputs.files(nativeVariantFiles)
+                    .withPropertyName("nativeVariantFiles")
+                    .withPathSensitivity(PathSensitivity.RELATIVE)
+                inputs.files(nativeVariantPluginJar)
+                    .withPropertyName("nativeVariantPluginJar")
+                    .withPathSensitivity(PathSensitivity.RELATIVE)
                 inputs.files(runtimeConfiguration)
 
                 outputs.upToDateWhen {

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PrepareTestTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PrepareTestTask.kt
@@ -24,6 +24,10 @@ abstract class PrepareTestTask : DefaultTask(), TestableAware {
 
     companion object : Registrable {
         override fun register(project: Project) {
+            project.registerTask<PrepareSandboxTask>(Tasks.PREPARE_TEST_SANDBOX, configureWithType = false) {
+                includeCurrentNativeVariant()
+            }
+
             project.registerTask<PrepareTestTask>(Tasks.PREPARE_TEST) {
                 val prepareTestSandboxTaskProvider = project.tasks.named<PrepareSandboxTask>(Tasks.PREPARE_TEST_SANDBOX)
                 applySandboxFrom(prepareTestSandboxTaskProvider)

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PublishPluginTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PublishPluginTask.kt
@@ -5,7 +5,7 @@ package org.jetbrains.intellij.platform.gradle.tasks
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
@@ -38,10 +38,10 @@ abstract class PublishPluginTask : DefaultTask() {
      * @see BuildPluginTask.archiveFile
      * @see IntelliJPlatformExtension.Signing
      */
-    @get:InputFile
+    @get:InputFiles
     @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    abstract val archiveFile: RegularFileProperty
+    abstract val archiveFiles: ConfigurableFileCollection
 
     /**
      * Specifies the URL host of a plugin repository.
@@ -98,10 +98,7 @@ abstract class PublishPluginTask : DefaultTask() {
             throw GradleException("'token' property must be specified for plugin publishing")
         }
 
-        val path = archiveFile.asPath
-        val pluginId = withIdePluginManager(temporaryDir.toPath()) {
-            it.safelyCreatePlugin(path, suppressPluginProblems = false).getOrThrow().pluginId
-        }
+        val paths = archiveFiles.files.map { it.toPath() }
 
         val resolvedHost = host.get()
         val useIdeServices = ideServices.get()
@@ -118,24 +115,30 @@ abstract class PublishPluginTask : DefaultTask() {
             false -> PluginRepositoryFactory.create(resolvedHost, resolvedToken)
         }
 
-        resolvedChannels.forEach { channel ->
-            log.info("Uploading plugin '$pluginId' from '$path' to '$resolvedHost', channel: '$channel'")
-            try {
-                repositoryClient.uploader.uploadUpdateByXmlIdAndFamily(
-                    id = pluginId as StringPluginId,
-                    family = ProductFamily.INTELLIJ,
-                    file = path.toFile(),
-                    channel = channel.takeIf { it != "default" },
-                    notes = null,
-                    isHidden = isHidden,
-                )
-                log.info("Uploaded successfully")
-            } catch (exception: Exception) {
-                if (useIdeServices && exception.isIdeServicesUploadResponseParsingFailure()) {
-                    log.warn("Uploaded successfully; ignoring IDE Services upload response parsing failure.")
-                    log.debug("IDE Services upload response parsing failure", exception)
-                } else {
-                    throw GradleException("Failed to upload plugin: ${exception.message}", exception)
+        paths.forEach { path ->
+            val pluginId = withIdePluginManager(temporaryDir.toPath()) {
+                it.safelyCreatePlugin(path, suppressPluginProblems = false).getOrThrow().pluginId
+            }
+
+            resolvedChannels.forEach { channel ->
+                log.info("Uploading plugin '$pluginId' from '$path' to '$resolvedHost', channel: '$channel'")
+                try {
+                    repositoryClient.uploader.uploadUpdateByXmlIdAndFamily(
+                        id = pluginId as StringPluginId,
+                        family = ProductFamily.INTELLIJ,
+                        file = path.toFile(),
+                        channel = channel.takeIf { it != "default" },
+                        notes = null,
+                        isHidden = isHidden,
+                    )
+                    log.info("Uploaded successfully")
+                } catch (exception: Exception) {
+                    if (useIdeServices && exception.isIdeServicesUploadResponseParsingFailure()) {
+                        log.warn("Uploaded successfully; ignoring IDE Services upload response parsing failure.")
+                        log.debug("IDE Services upload response parsing failure", exception)
+                    } else {
+                        throw GradleException("Failed to upload plugin: ${exception.message}", exception)
+                    }
                 }
             }
         }
@@ -160,7 +163,9 @@ abstract class PublishPluginTask : DefaultTask() {
             project.registerTask<PublishPluginTask>(Tasks.PUBLISH_PLUGIN) {
                 val publishingProvider = project.extensionProvider.map { it.publishing }
                 val buildPluginTaskProvider = project.tasks.named<BuildPluginTask>(Tasks.BUILD_PLUGIN)
+                val buildPluginVariantsTaskProvider = project.tasks.named<BuildPluginVariantsTask>(Tasks.BUILD_PLUGIN_VARIANTS)
                 val signPluginTaskProvider = project.tasks.named<SignPluginTask>(Tasks.SIGN_PLUGIN)
+                val nativeVariantsEnabledProvider = project.extensionProvider.flatMap { it.nativeVariants.enabled }
 
                 val isOffline = project.gradle.startParameter.isOffline
 
@@ -170,20 +175,28 @@ abstract class PublishPluginTask : DefaultTask() {
                 channels.convention(publishingProvider.flatMap { it.channels })
                 hidden.convention(publishingProvider.flatMap { it.hidden })
 
-                // TODO: can this be done in any other way?
-                archiveFile.convention(
-                    signPluginTaskProvider
-                        .map { it.didWork }
-                        .flatMap { signed ->
-                            when {
-                                signed -> signPluginTaskProvider.flatMap { it.signedArchiveFile }
-                                else -> buildPluginTaskProvider.flatMap { it.archiveFile }
+                archiveFiles.from(
+                    nativeVariantsEnabledProvider.flatMap { enabled ->
+                        when (enabled) {
+                            true -> buildPluginVariantsTaskProvider.map { it.archiveFiles }
+                            else -> signPluginTaskProvider.map { it.didWork }.flatMap { signed ->
+                                when {
+                                    signed -> signPluginTaskProvider.flatMap { it.signedArchiveFile }
+                                    else -> buildPluginTaskProvider.flatMap { it.archiveFile }
+                                }
                             }
                         }
+                    },
+                )
+                dependsOn(
+                    nativeVariantsEnabledProvider.map { enabled ->
+                        when (enabled) {
+                            true -> listOf(buildPluginVariantsTaskProvider)
+                            false -> listOf(buildPluginTaskProvider, signPluginTaskProvider)
+                        }
+                    },
                 )
 
-                dependsOn(buildPluginTaskProvider)
-                dependsOn(signPluginTaskProvider)
                 onlyIf { !isOffline }
             }
     }

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTask.kt
@@ -6,6 +6,7 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
+import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.*
@@ -16,6 +17,7 @@ import org.gradle.process.ExecOperations
 import org.gradle.process.JavaExecSpec
 import org.gradle.process.JavaForkOptions
 import org.jetbrains.intellij.platform.gradle.Constants.Plugin
+import org.jetbrains.intellij.platform.gradle.Constants.Sandbox
 import org.jetbrains.intellij.platform.gradle.Constants.Tasks
 import org.jetbrains.intellij.platform.gradle.argumentProviders.ComposeHotReloadArgumentProvider
 import org.jetbrains.intellij.platform.gradle.argumentProviders.SplitModeArgumentProvider
@@ -24,6 +26,7 @@ import org.jetbrains.intellij.platform.gradle.resolvers.path.resolveJavaRuntimeD
 import org.jetbrains.intellij.platform.gradle.tasks.aware.*
 import org.jetbrains.intellij.platform.gradle.utils.Logger
 import org.jetbrains.intellij.platform.gradle.utils.asPath
+import org.jetbrains.intellij.platform.gradle.utils.extensionProvider
 import org.jetbrains.intellij.platform.gradle.utils.safePathString
 import java.io.ByteArrayOutputStream
 import java.io.OutputStream
@@ -672,22 +675,29 @@ abstract class RunIdeTask : JavaExec(), RunnableIdeAware, SplitModeAware, Plugin
     }
 
     companion object : Registrable {
+        private const val PREPARE_SANDBOX_RUN_IDE = "${Tasks.PREPARE_SANDBOX}_${Tasks.RUN_IDE}"
         private const val PREPARE_SANDBOX_RUN_IDE_BACKEND = "${Tasks.PREPARE_SANDBOX}_${Tasks.RUN_IDE_BACKEND}"
         private const val PREPARE_SANDBOX_RUN_IDE_FRONTEND = "${Tasks.PREPARE_SANDBOX}_${Tasks.RUN_IDE_FRONTEND}"
 
         override fun register(project: Project) {
-            project.registerTask<RunIdeTask>(Tasks.RUN_IDE, configureWithType = false) {
-                val prepareSandboxTaskProvider = project.tasks.named<PrepareSandboxTask>(Tasks.PREPARE_SANDBOX)
-                applySandboxFrom(prepareSandboxTaskProvider)
+            project.registerTask<PrepareSandboxTask>(PREPARE_SANDBOX_RUN_IDE, configureWithType = false) {
+                includeCurrentNativeVariant()
             }
 
             project.registerTask<PrepareSandboxTask>(PREPARE_SANDBOX_RUN_IDE_BACKEND, configureWithType = false) {
+                includeCurrentNativeVariant()
                 splitMode.convention(true)
                 pluginInstallationTarget.convention(SplitModeAware.PluginInstallationTarget.BACKEND)
             }
             project.registerTask<PrepareSandboxTask>(PREPARE_SANDBOX_RUN_IDE_FRONTEND, configureWithType = false) {
+                includeCurrentNativeVariant()
                 splitMode.convention(true)
                 pluginInstallationTarget.convention(SplitModeAware.PluginInstallationTarget.FRONTEND)
+            }
+
+            project.registerTask<RunIdeTask>(Tasks.RUN_IDE, configureWithType = false) {
+                val prepareRunIdeSandboxTaskProvider = project.tasks.named<PrepareSandboxTask>(PREPARE_SANDBOX_RUN_IDE)
+                applySandboxFrom(prepareRunIdeSandboxTaskProvider)
             }
 
             project.registerTask<RunIdeTask>(Tasks.RUN_IDE_BACKEND, configureWithType = false) {

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/TestIdePerformanceTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/TestIdePerformanceTask.kt
@@ -134,11 +134,7 @@ abstract class TestIdePerformanceTask : JavaExec(), RunnableIdeAware, TestableAw
 
     companion object : Registrable {
 
-        internal val configuration: TestIdePerformanceTask.() -> Unit = {
-            val prepareTestIdePerformanceSandboxTaskProvider =
-                project.tasks.named<PrepareSandboxTask>(Tasks.PREPARE_TEST_IDE_PERFORMANCE_SANDBOX)
-            applySandboxFrom(prepareTestIdePerformanceSandboxTaskProvider)
-
+//        internal val configuration: TestIdePerformanceTask.() -> Unit = {
 //                artifactsDirectory.convention(extension.type.flatMap { type ->
 //                    extension.version.flatMap { version ->
 //                        project.layout.buildDirectory.dir(
@@ -169,14 +165,19 @@ abstract class TestIdePerformanceTask : JavaExec(), RunnableIdeAware, TestableAw
 //                        configurePluginDependency(project, plugin, extension, this, resolver)
 //                    }
 //                }
-        }
+//        }
 
-        override fun register(project: Project) =
-            project.registerTask<TestIdePerformanceTask>(
-                Tasks.TEST_IDE_PERFORMANCE,
-                configureWithType = false,
-                configuration = configuration
-            )
+        override fun register(project: Project) {
+            project.registerTask<PrepareSandboxTask>(Tasks.PREPARE_TEST_IDE_PERFORMANCE_SANDBOX, configureWithType = false) {
+                includeCurrentNativeVariant()
+            }
+
+            project.registerTask<TestIdePerformanceTask>(Tasks.TEST_IDE_PERFORMANCE, configureWithType = false) {
+                val prepareTestIdePerformanceSandboxTaskProvider =
+                    project.tasks.named<PrepareSandboxTask>(Tasks.PREPARE_TEST_IDE_PERFORMANCE_SANDBOX)
+                applySandboxFrom(prepareTestIdePerformanceSandboxTaskProvider)
+            }
+        }
     }
 
 //    private fun resolveLatestPluginUpdate(pluginId: String, buildNumber: String, channel: String = "") =

--- a/src/test/kotlin/org/jetbrains/intellij/platform/gradle/VariantTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/platform/gradle/VariantTest.kt
@@ -1,0 +1,35 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+
+package org.jetbrains.intellij.platform.gradle
+
+import org.gradle.api.GradleException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class VariantTest {
+
+    @Test
+    fun `resolve current native variant`() {
+        mapOf(
+            ("Linux" to "amd64") to Variant("linux", "x86_64"),
+            ("Linux" to "aarch64") to Variant("linux", "arm64"),
+            ("Mac OS X" to "x86_64") to Variant("mac", "x86_64"),
+            ("Darwin" to "arm64") to Variant("mac", "arm64"),
+            ("Windows 11" to "x64") to Variant("windows", "x86_64"),
+            ("Windows 11" to "arm64") to Variant("windows", "arm64"),
+        ).forEach { (system, expected) ->
+            assertEquals(expected, currentVariant(system.first, system.second))
+        }
+    }
+
+    @Test
+    fun `reject unsupported current native variant`() {
+        assertFailsWith<GradleException> {
+            currentVariant("FreeBSD", "x86_64")
+        }
+        assertFailsWith<GradleException> {
+            currentVariant("Linux", "riscv64")
+        }
+    }
+}

--- a/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/BuildPluginTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/BuildPluginTaskTest.kt
@@ -119,6 +119,70 @@ class BuildPluginTaskTest : IntelliJPluginTestBase() {
     }
 
     @Test
+    fun `build native plugin variant from shared sandbox`() {
+        writeJavaFile()
+
+        pluginXml write //language=xml
+                """
+                <idea-plugin>
+                  <name>MyPluginName</name>
+                  <vendor>JetBrains</vendor>
+                </idea-plugin>
+                """.trimIndent()
+
+        dir.resolve("native/linux-arm64/bin/native.txt") write "linux-arm64"
+
+        buildFile write //language=kotlin
+                """
+                intellijPlatform {
+                    nativeVariants {
+                        enabled = true
+                        linux.arm64.from(file("native/linux-arm64"))
+                    }
+                }
+                """.trimIndent()
+
+        build(Tasks.BUILD_PLUGIN).apply {
+            assertNull(task(":${Tasks.BUILD_PLUGIN_VARIANTS}_linux_arm64"))
+        }
+
+        buildWithConfigurationCache(Tasks.BUILD_PLUGIN_VARIANTS).apply {
+            assertNotNull(task(":${Tasks.BUILD_PLUGIN_VARIANTS}_linux_arm64"))
+            assertNull(task(":${Tasks.BUILD_PLUGIN}"))
+            assertNull(task(":${Tasks.PREPARE_SANDBOX}_linux_arm64"))
+        }
+
+        buildWithConfigurationCache(Tasks.BUILD_PLUGIN_VARIANTS) {
+            assertConfigurationCacheReused()
+        }
+
+        buildDirectory.resolve("distributions/projectName-1.0.0-linux-arm64.zip").let { distribution ->
+            assertExists(distribution)
+
+            distribution.toZip().use { zip ->
+                assertTrue("projectName/bin/native.txt" in collectPaths(zip))
+                assertEquals("linux-arm64", fileText(zip, "projectName/bin/native.txt"))
+
+                zip.extract("projectName/lib/projectName-1.0.0.jar").toZip().use { jar ->
+                    assertEquals(
+                        """
+                        <idea-plugin>
+                          <idea-version since-build="$sinceBuild" />
+                          <version>1.0.0-linux-arm64</version>
+                          <name>MyPluginName</name>
+                          <vendor>JetBrains</vendor>
+                          <depends>com.intellij.modules.os.linux</depends>
+                          <depends>com.intellij.modules.arch.arm64</depends>
+                        </idea-plugin>
+                        """.trimIndent(),
+                        fileText(jar, "META-INF/plugin.xml"),
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
     fun `build plugin distribution with Kotlin`() {
         writeJavaFile()
         writeKotlinUIFile()

--- a/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PublishPluginTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/PublishPluginTaskTest.kt
@@ -7,10 +7,12 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.jetbrains.intellij.platform.gradle.*
 import org.jetbrains.intellij.platform.gradle.Constants.Tasks
 import java.net.InetSocketAddress
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class PublishPluginTaskTest : IntelliJPluginTestBase() {
 
@@ -169,7 +171,79 @@ class PublishPluginTaskTest : IntelliJPluginTestBase() {
                 assertContains("Uploaded successfully; ignoring IDE Services upload response parsing failure.", output)
             }
 
-            assertEquals(1, requests.get())
+            assertEquals(1, requests.size)
+        }
+    }
+
+    @Test
+    fun `publish all native variant archives`() {
+        pluginXml overwrite //language=xml
+                """
+                <idea-plugin>
+                    <id>org.example.plugin</id>
+                    <name>PluginName</name>
+                    <version>0.0.1</version>
+                    <description>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</description>
+                    <vendor>JetBrains</vendor>
+                    <depends>com.intellij.modules.platform</depends>
+                </idea-plugin>
+                """.trimIndent()
+
+        withIdeServicesUploadResponse(
+            """
+            {
+              "id" : "org.example.plugin",
+              "name" : "PluginName",
+              "vendor" : "JetBrains",
+              "minVersion" : "1.0",
+              "maxVersion" : "1.4.0",
+              "isPrivate" : true
+            }
+            """.trimIndent()
+        ) { serverUrl, requests ->
+            buildFile write //language=kotlin
+                    """
+                    intellijPlatform {
+                        nativeVariants {
+                            enabled = true
+                        }
+                        publishing {
+                            token = "ide-services-token"
+                            host = "$serverUrl"
+                            ideServices = true
+                            channels = listOf("Stable")
+                        }
+                    }
+                    """.trimIndent()
+
+            buildWithConfigurationCache(Tasks.PUBLISH_PLUGIN, environment = pluginTemplateEnvironment()) {
+                assertTaskOutcome(Tasks.PUBLISH_PLUGIN, TaskOutcome.SUCCESS)
+                assertNotNull(task(":${Tasks.BUILD_PLUGIN_VARIANTS}"))
+                assertNull(task(":${Tasks.BUILD_PLUGIN}"))
+                assertNull(task(":${Tasks.SIGN_PLUGIN}"))
+
+                variants.forEach { variant ->
+                    assertTaskOutcome("${Tasks.BUILD_PLUGIN_VARIANTS}_${variant.os}_${variant.arch}", TaskOutcome.SUCCESS)
+                }
+            }
+            buildWithConfigurationCache(Tasks.PUBLISH_PLUGIN, environment = pluginTemplateEnvironment()) {
+                assertConfigurationCacheReused()
+                assertTaskOutcome(Tasks.PUBLISH_PLUGIN, TaskOutcome.SUCCESS)
+            }
+
+            val expectedArchiveNames = variants
+                .map { "projectName-1.0.0-${it.os}-${it.arch}.zip" }
+                .flatMap { listOf(it, it) }
+                .sorted()
+            val uploadedArchiveNames = requests
+                .map { request ->
+                    requireNotNull(Regex("""filename="?([^";\r\n]+\.zip)"?""").find(request)) {
+                        "No ZIP archive filename found in upload request"
+                    }.groupValues[1]
+                }
+                .sorted()
+
+            assertEquals(expectedArchiveNames, uploadedArchiveNames)
         }
     }
 
@@ -248,12 +322,11 @@ class PublishPluginTaskTest : IntelliJPluginTestBase() {
         }
     }
 
-    private fun withIdeServicesUploadResponse(responseBody: String, block: (String, AtomicInteger) -> Unit) {
-        val requests = AtomicInteger()
+    private fun withIdeServicesUploadResponse(responseBody: String, block: (String, List<String>) -> Unit) {
+        val requests = CopyOnWriteArrayList<String>()
         val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).apply {
             createContext("/api/plugins") { exchange ->
-                requests.incrementAndGet()
-                exchange.requestBody.use { it.readBytes() }
+                requests += exchange.requestBody.use { it.readBytes().toString(Charsets.ISO_8859_1) }
 
                 val bytes = responseBody.toByteArray()
                 exchange.responseHeaders.add("Content-Type", "application/json")

--- a/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTaskTest.kt
@@ -97,44 +97,25 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
         }
     }
 
-    private fun assertRunIdePluginsDirectory(directoryName: String) {
-        val assertionTask = "assertRunIdePluginsDirectory"
-
-        buildFile write //language=kotlin
-                """
-                val runIdePluginsDirectory = tasks.named<RunIdeTask>("${Tasks.RUN_IDE}").flatMap { it.sandboxPluginsDirectory }
-                tasks.register("$assertionTask") {
-                    doLast {
-                        check(runIdePluginsDirectory.get().asFile.name == "$directoryName")
-                    }
-                }
-                """.trimIndent()
-
-        build(assertionTask)
-    }
-
     @Test
-    fun `runIde overlays current native variant on default sandbox without changing distribution`() {
+    fun `runIde uses current native variant without changing base sandbox or distribution`() {
         configureNativeVariants()
         val prepareRunIdeSandbox = "${Tasks.PREPARE_SANDBOX}_${Tasks.RUN_IDE}"
         val prepareCurrentVariant = "${Tasks.PREPARE_PLUGIN_VARIANT}_${hostVariant.os}_${hostVariant.arch}"
         dir.resolve("base/bin/collision.txt") write "base"
-        dir.resolve("base/shared.txt") write "shared"
         buildFile write //language=kotlin
                 """
-                tasks.named<PrepareSandboxTask>("${Tasks.PREPARE_SANDBOX}") {
+                tasks.named<PrepareSandboxTask>("$prepareRunIdeSandbox") {
                     from("base") {
                         into("projectName")
                     }
                 }
                 """.trimIndent()
 
-        assertRunIdePluginsDirectory("plugins_runIde")
-
         build(Tasks.RUN_IDE, args = listOf("--dry-run")) {
-            assertTrue(":${Tasks.PREPARE_SANDBOX} SKIPPED" in output.lineSequence())
             assertTrue(":$prepareRunIdeSandbox SKIPPED" in output.lineSequence())
             assertTrue(":$prepareCurrentVariant SKIPPED" in output.lineSequence())
+            assertFalse(":${Tasks.PREPARE_SANDBOX} SKIPPED" in output.lineSequence())
         }
 
         buildWithConfigurationCache(prepareRunIdeSandbox, Tasks.BUILD_PLUGIN)
@@ -144,13 +125,8 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
 
         assertCurrentNativeVariant(sandbox.resolve("plugins_runIde/projectName"))
         assertBasePlugin(sandbox.resolve("plugins/projectName"))
-        assertEquals("base", sandbox.resolve("plugins/projectName/bin/collision.txt").readText().trim())
-        assertEquals("shared", sandbox.resolve("plugins_runIde/projectName/shared.txt").readText().trim())
-        assertEquals("shared", sandbox.resolve("plugins/projectName/shared.txt").readText().trim())
 
         buildDirectory.resolve("distributions/projectName-1.0.0.zip").toZip().use { distribution ->
-            assertEquals("base", fileText(distribution, "projectName/bin/collision.txt"))
-            assertEquals("shared", fileText(distribution, "projectName/shared.txt"))
             variants.forEach { variant ->
                 assertFalse("projectName/bin/${variant.os}-${variant.arch}.txt" in collectPaths(distribution))
             }
@@ -493,7 +469,7 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
     @Test
     fun `runIde keeps old log directories by default`() {
         configureFakeJavaLauncher()
-        val staleLogFile = sandbox.resolve("${Sandbox.LOG}/old-session/idea.log")
+        val staleLogFile = sandbox.resolve("${Sandbox.LOG}_${Tasks.RUN_IDE}/old-session/idea.log")
         staleLogFile.parent.createDirectories()
         staleLogFile.toFile().writeText("stale")
 
@@ -514,7 +490,7 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
             """.trimIndent()
         )
 
-        val logDirectory = sandbox.resolve(Sandbox.LOG)
+        val logDirectory = sandbox.resolve("${Sandbox.LOG}_${Tasks.RUN_IDE}")
         val staleLogFile = logDirectory.resolve("old-session/idea.log")
         staleLogFile.parent.createDirectories()
         staleLogFile.toFile().writeText("stale")

--- a/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTaskTest.kt
@@ -7,9 +7,13 @@ import org.jetbrains.intellij.platform.gradle.Constants.Tasks
 import org.jetbrains.intellij.platform.gradle.IntelliJPluginTestBase
 import org.jetbrains.intellij.platform.gradle.assertContains
 import org.jetbrains.intellij.platform.gradle.assertNotContains
+import org.jetbrains.intellij.platform.gradle.buildDirectory
 import org.jetbrains.intellij.platform.gradle.buildFile
 import org.jetbrains.intellij.platform.gradle.cacheDirectory
+import org.jetbrains.intellij.platform.gradle.currentVariant
 import org.jetbrains.intellij.platform.gradle.overwrite
+import org.jetbrains.intellij.platform.gradle.pluginXml
+import org.jetbrains.intellij.platform.gradle.variants
 import org.jetbrains.intellij.platform.gradle.write
 import javax.tools.ToolProvider
 import kotlin.io.path.createDirectories
@@ -17,6 +21,7 @@ import kotlin.io.path.exists
 import kotlin.io.path.invariantSeparatorsPathString
 import kotlin.io.path.readText
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -26,6 +31,161 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
     private val sandbox
         get() = cacheDirectory.resolve(Sandbox.CONTAINER).resolve("projectName")
             .resolve("$intellijPlatformType-$intellijPlatformVersion")
+    private val hostVariant = currentVariant(System.getProperty("os.name"), System.getProperty("os.arch"))
+
+    private fun configureNativeVariants(enabled: Boolean = true) {
+        pluginXml write //language=xml
+                """
+                <idea-plugin>
+                  <name>MyPluginName</name>
+                  <vendor>JetBrains</vendor>
+                </idea-plugin>
+                """.trimIndent()
+
+        variants.forEach { variant ->
+            dir.resolve("native/${variant.os}-${variant.arch}/bin/${variant.os}-${variant.arch}.txt") write "${variant.os}-${variant.arch}"
+            dir.resolve("native/${variant.os}-${variant.arch}/bin/collision.txt") write "${variant.os}-${variant.arch}"
+        }
+
+        buildFile write //language=kotlin
+                """
+                intellijPlatform {
+                    nativeVariants {
+                        enabled = $enabled
+                        linux.x86_64.from(file("native/linux-x86_64"))
+                        linux.arm64.from(file("native/linux-arm64"))
+                        mac.x86_64.from(file("native/mac-x86_64"))
+                        mac.arm64.from(file("native/mac-arm64"))
+                        windows.x86_64.from(file("native/windows-x86_64"))
+                        windows.arm64.from(file("native/windows-arm64"))
+                    }
+                }
+                """.trimIndent()
+    }
+
+    private fun assertCurrentNativeVariant(pluginDirectory: java.nio.file.Path) {
+        variants.forEach { variant ->
+            val marker = pluginDirectory.resolve("bin/${variant.os}-${variant.arch}.txt")
+            when (variant) {
+                hostVariant -> assertTrue(marker.exists(), "Expected current native variant marker: $marker")
+                else -> assertFalse(marker.exists(), "Unexpected native variant marker: $marker")
+            }
+        }
+        assertEquals(
+            "${hostVariant.os}-${hostVariant.arch}",
+            pluginDirectory.resolve("bin/collision.txt").readText().trim(),
+        )
+
+        pluginDirectory.resolve("lib/projectName-1.0.0.jar").toZip().use { jar ->
+            val descriptor = fileText(jar, "META-INF/plugin.xml")
+            assertContains("<version>1.0.0-${hostVariant.os}-${hostVariant.arch}</version>", descriptor)
+            assertContains("<depends>com.intellij.modules.os.${hostVariant.os}</depends>", descriptor)
+            assertContains("<depends>com.intellij.modules.arch.${hostVariant.arch}</depends>", descriptor)
+        }
+    }
+
+    private fun assertBasePlugin(pluginDirectory: java.nio.file.Path) {
+        variants.forEach { variant ->
+            assertFalse(pluginDirectory.resolve("bin/${variant.os}-${variant.arch}.txt").exists())
+        }
+
+        pluginDirectory.resolve("lib/projectName-1.0.0.jar").toZip().use { jar ->
+            val descriptor = fileText(jar, "META-INF/plugin.xml")
+            assertContains("<version>1.0.0</version>", descriptor)
+            assertNotContains("<depends>com.intellij.modules.os.", descriptor)
+            assertNotContains("<depends>com.intellij.modules.arch.", descriptor)
+        }
+    }
+
+    private fun assertRunIdePluginsDirectory(directoryName: String) {
+        val assertionTask = "assertRunIdePluginsDirectory"
+
+        buildFile write //language=kotlin
+                """
+                val runIdePluginsDirectory = tasks.named<RunIdeTask>("${Tasks.RUN_IDE}").flatMap { it.sandboxPluginsDirectory }
+                tasks.register("$assertionTask") {
+                    doLast {
+                        check(runIdePluginsDirectory.get().asFile.name == "$directoryName")
+                    }
+                }
+                """.trimIndent()
+
+        build(assertionTask)
+    }
+
+    @Test
+    fun `runIde overlays current native variant on default sandbox without changing distribution`() {
+        configureNativeVariants()
+        val prepareRunIdeSandbox = "${Tasks.PREPARE_SANDBOX}_${Tasks.RUN_IDE}"
+        val prepareCurrentVariant = "${Tasks.PREPARE_PLUGIN_VARIANT}_${hostVariant.os}_${hostVariant.arch}"
+        dir.resolve("base/bin/collision.txt") write "base"
+        dir.resolve("base/shared.txt") write "shared"
+        buildFile write //language=kotlin
+                """
+                tasks.named<PrepareSandboxTask>("${Tasks.PREPARE_SANDBOX}") {
+                    from("base") {
+                        into("projectName")
+                    }
+                }
+                """.trimIndent()
+
+        assertRunIdePluginsDirectory("plugins_runIde")
+
+        build(Tasks.RUN_IDE, args = listOf("--dry-run")) {
+            assertTrue(":${Tasks.PREPARE_SANDBOX} SKIPPED" in output.lineSequence())
+            assertTrue(":$prepareRunIdeSandbox SKIPPED" in output.lineSequence())
+            assertTrue(":$prepareCurrentVariant SKIPPED" in output.lineSequence())
+        }
+
+        buildWithConfigurationCache(prepareRunIdeSandbox, Tasks.BUILD_PLUGIN)
+        buildWithConfigurationCache(prepareRunIdeSandbox, Tasks.BUILD_PLUGIN) {
+            assertConfigurationCacheReused()
+        }
+
+        assertCurrentNativeVariant(sandbox.resolve("plugins_runIde/projectName"))
+        assertBasePlugin(sandbox.resolve("plugins/projectName"))
+        assertEquals("base", sandbox.resolve("plugins/projectName/bin/collision.txt").readText().trim())
+        assertEquals("shared", sandbox.resolve("plugins_runIde/projectName/shared.txt").readText().trim())
+        assertEquals("shared", sandbox.resolve("plugins/projectName/shared.txt").readText().trim())
+
+        buildDirectory.resolve("distributions/projectName-1.0.0.zip").toZip().use { distribution ->
+            assertEquals("base", fileText(distribution, "projectName/bin/collision.txt"))
+            assertEquals("shared", fileText(distribution, "projectName/shared.txt"))
+            variants.forEach { variant ->
+                assertFalse("projectName/bin/${variant.os}-${variant.arch}.txt" in collectPaths(distribution))
+            }
+            distribution.extract("projectName/lib/projectName-1.0.0.jar").toZip().use { jar ->
+                val descriptor = fileText(jar, "META-INF/plugin.xml")
+                assertContains("<version>1.0.0</version>", descriptor)
+                assertNotContains("<depends>com.intellij.modules.os.", descriptor)
+                assertNotContains("<depends>com.intellij.modules.arch.", descriptor)
+            }
+        }
+    }
+
+    @Test
+    fun `split and custom runIde sandboxes use current native variant`() {
+        configureNativeVariants()
+        val customRunIde = "customRunIde"
+        buildFile write //language=kotlin
+                """
+                val $customRunIde by intellijPlatformTesting.runIde.registering {
+                    task {
+                        enabled = false
+                    }
+                }
+                """.trimIndent()
+
+        build(
+            "${Tasks.PREPARE_SANDBOX}_${Tasks.RUN_IDE_BACKEND}",
+            "${Tasks.PREPARE_SANDBOX}_${Tasks.RUN_IDE_FRONTEND}",
+            "${Tasks.PREPARE_SANDBOX}_$customRunIde",
+        )
+
+        assertCurrentNativeVariant(sandbox.resolve("plugins_runIdeBackend/projectName"))
+        assertCurrentNativeVariant(sandbox.resolve("plugins_runIdeFrontend/frontend/projectName"))
+        assertCurrentNativeVariant(sandbox.resolve("plugins_$customRunIde/projectName"))
+    }
 
     private fun configureFrontendJoinLinkProvider(
         delayMs: Int,
@@ -127,7 +287,7 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
         helperSource overwrite //language=java
                 """
                 package fake.launcher;
-
+                
                 import java.lang.management.ManagementFactory;
                 import java.net.ServerSocket;
                 import java.nio.file.Files;
@@ -136,10 +296,10 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
                 import java.util.ArrayList;
                 import java.util.Arrays;
                 import java.util.List;
-
+                
                 public final class FakeLauncher {
                     private FakeLauncher() {}
-
+                
                     public static void run(String mainClass, String[] args) throws Exception {
                         var debugLines = new ArrayList<String>();
                         debugLines.add("=== fake java start ===");
@@ -148,7 +308,7 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
                         for (var arg : args) {
                             debugLines.add("ARG=" + arg);
                         }
-
+                
                         printAndLog("JETBRAINS_CLIENT_JDK=" + getenv("JETBRAINS_CLIENT_JDK"), debugLines);
                         printAndLog("JETBRAINS_CLIENT_VM_OPTIONS=" + getenv("JETBRAINS_CLIENT_VM_OPTIONS"), debugLines);
                         printAndLog("JETBRAINS_CLIENT_PROPERTIES=" + getenv("JETBRAINS_CLIENT_PROPERTIES"), debugLines);
@@ -156,17 +316,17 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
                         readVmOptions(debugLines);
                         printAndLog("JETBRAINS_CLIENT_VM_OPTIONS_CONTENT_END", debugLines);
                         printAndLog("MAIN_CLASS=" + mainClass, debugLines);
-
+                
                         var jvmArgs = String.join(" ", filteredInputArguments());
                         if (!jvmArgs.isBlank()) {
                             printAndLog("JVM_ARGS=" + jvmArgs, debugLines);
                         }
-
+                
                         var appArgs = String.join(" ", args);
                         if (!appArgs.isBlank()) {
                             printAndLog("APP_ARGS=" + appArgs, debugLines);
                         }
-
+                
                         var argsList = Arrays.asList(args);
                         var exitCode = resolveExitCode(argsList);
                         if (argsList.contains("serverMode")) {
@@ -175,7 +335,7 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
                             if (portOptionIndex >= 0 && portOptionIndex + 1 < args.length) {
                                 port = Integer.parseInt(args[portOptionIndex + 1]);
                             }
-
+                
                             var aliveMs = System.getProperty("fake.backend.alive.ms");
                             if (aliveMs != null && !aliveMs.isBlank()) {
                                 try (var serverSocket = new ServerSocket(port)) {
@@ -190,14 +350,14 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
                                 printAndLog("Join link: tcp://127.0.0.1:" + port + "#cb=fake", debugLines);
                             }
                         }
-
+                
                         debugLines.add("=== fake java end ===");
                         writeDebugLog(debugLines);
                         if (exitCode != 0) {
                             System.exit(exitCode);
                         }
                     }
-
+                
                     private static int resolveExitCode(List<String> argsList) {
                         var propertyName = "fake.exit.code";
                         if (argsList.contains("serverMode")) {
@@ -205,34 +365,34 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
                         } else if (argsList.contains("thinClient")) {
                             propertyName = "fake.frontend.exit.code";
                         }
-
+                
                         var configured = System.getProperty(propertyName, System.getProperty("fake.exit.code", "0"));
                         if (configured == null || configured.isBlank()) {
                             return 0;
                         }
                         return Integer.parseInt(configured);
                     }
-
+                
                     private static String getenv(String name) {
                         return System.getenv().getOrDefault(name, "");
                     }
-
+                
                     private static void readVmOptions(List<String> debugLines) throws Exception {
                         var vmOptions = getenv("JETBRAINS_CLIENT_VM_OPTIONS");
                         if (vmOptions.isBlank()) {
                             return;
                         }
-
+                
                         var vmOptionsPath = Path.of(vmOptions);
                         if (!Files.exists(vmOptionsPath)) {
                             return;
                         }
-
+                
                         for (var line : Files.readAllLines(vmOptionsPath)) {
                             printAndLog(line, debugLines);
                         }
                     }
-
+                
                     private static List<String> filteredInputArguments() {
                         var fakeLauncherClasses = System.getProperty("fake.java.fakeLauncherClasses", "");
                         var filtered = new ArrayList<String>();
@@ -247,12 +407,12 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
                         }
                         return filtered;
                     }
-
+                
                     private static void printAndLog(String line, List<String> debugLines) {
                         System.out.println(line);
                         debugLines.add(line);
                     }
-
+                
                     private static void writeDebugLog(List<String> debugLines) throws Exception {
                         var debugLog = System.getProperty("fake.java.debug.log", "");
                         if (debugLog.isBlank()) {
@@ -271,10 +431,10 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
         ideaMainSource overwrite //language=java
                 """
                 package com.intellij.idea;
-
+                
                 public final class Main {
                     private Main() {}
-
+                
                     public static void main(String[] args) throws Exception {
                         fake.launcher.FakeLauncher.run(Main.class.getName(), args);
                     }
@@ -283,10 +443,10 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
         intellijLoaderSource overwrite //language=java
                 """
                 package com.intellij.platform.runtime.loader;
-
+                
                 public final class IntellijLoader {
                     private IntellijLoader() {}
-
+                
                     public static void main(String[] args) throws Exception {
                         fake.launcher.FakeLauncher.run(IntellijLoader.class.getName(), args);
                     }


### PR DESCRIPTION
Add opt-in OS- and architecture-specific plugin distributions.

- Introduce the `intellijPlatform.nativeVariants` DSL.
- Support Linux, macOS, and Windows on `x86_64` and `arm64`.
- Add `buildPluginVariants` and per-target build tasks.
- Include target-specific files while reusing the shared plugin sandbox.
- Patch variant JARs with target-specific versions and module dependencies.
- Preserve the existing base `buildPlugin` distribution.
- Support configuration-cache storage and reuse.